### PR TITLE
[PP-1562] In breadcrumbs, change “Pay” to “GOV.UK Pay”

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -5,7 +5,7 @@
                 <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
             </li>
             <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-                <a href="#main" itemprop="item"><span itemprop="name">Pay</span></a>
+                <a href="#main" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>
             </li>
         </ol>
     </nav>


### PR DESCRIPTION
“Components > Pay” becomes “Components > GOV.UK Pay” (requested by @roryjhs)

<img width="901" alt="Screenshot of Pay product page with fixed name" src="https://cloud.githubusercontent.com/assets/24316348/22201540/f6d69bd0-e15b-11e6-8eee-b25a2407e738.png">
