### PR TITLE
PP-1562 github-release script to create releases and publish on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-# Product Page Example
+# Pay Product Page
 
-> :rotating_light: This project is **unstable** and **in development**, and should not be used in a production-grade product. :rotating_light:
-
-## Running Example Locally
+## Running Locally
 
 - `bundle install`
 - `bower install`
 - `bundle exec middleman server`
 - `open http://localhost:4567`
+
+## Building a Static Copy of the Site
+
+- `bundle install`
+- `bower install`
+- `bundle exec middleman build`
+
+Check the `build` directory for the output.
 
 ## Components
 
@@ -25,3 +31,21 @@ Look at the CSS for the individual components for usage examples and notes.
 - [Related Items](source/stylesheets/modules/_related-items.scss)
 - [Skip Link](source/stylesheets/modules/_skip-link.scss)
 - [Sub Navigation](source/stylesheets/modules/_sub-navigation.scss)
+
+## Releasing a Static Copy of the Site
+
+The command line script `github-release` allows you to easily build an artifact containing the generated static site and publish it on GitHub in a format that makes it suitable for use as a Node.js dependency.
+
+Using the GitHub API, the script creates a new release from `master` with an associated tag. On your local machine, it then builds a static version of the site (using `middleman`) from your working copy, adds a `package.json` file (which makes it a Node.js module) inside the resulting `build` directory, `tar`s and `gzip`s the `build` directory, then attaches the gzipped tarball as a binary to the release in GitHub, where it appears alongside the source code downloads on the releases page. This artifact is available over HTTPS and can be used as a dependency in a Node.js project.
+
+In order to run the script, you need to declare an environment variable called `GITHUB_TOKEN` containing your GitHub authentication token:
+
+`GITHUB_TOKEN=xxx`
+
+Then you can run the script:
+
+`bin/github-release --version 1.0.1 publish`
+
+The `--version` argument specifies the version of the new release (pick something sensible based on the previous releases). This version number is used for the release version, tag name, `version` property in the `package.json` and as part of the file name for the binary.
+
+The script is bash and has no dependencies other than `curl` and those necessary for `middleman`.

--- a/bin/github-release
+++ b/bin/github-release
@@ -1,0 +1,16 @@
+#/usr/bin/env sh
+
+# Gets the lib folder relative to this script location
+lib_path="$(cd "$(dirname "$0")/../lib";pwd)"
+
+. "$lib_path/common.sh"   || exit 1
+. "$lib_path/dispatch.sh" || exit 1
+. "$lib_path/logging.sh"  || exit 1
+. "$lib_path/github-release/cli.sh"  || exit 1
+. "$lib_path/github-release/github-release.sh"  || exit 1
+
+# This variable should not be used anymore
+unset lib_path
+
+githubrelease "${@:-}"
+

--- a/github-release.sh
+++ b/github-release.sh
@@ -1,0 +1,3 @@
+#/usr/bin/env sh
+
+

--- a/github-release.sh
+++ b/github-release.sh
@@ -1,3 +1,0 @@
-#/usr/bin/env sh
-
-

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,9 @@
+# Common settings for all scripts
+
+# Enables word split on zsh
+setopt SH_WORD_SPLIT >/dev/null 2>&1 || :
+
+# -e exits on any untreated error
+# -u exits on any undeclared variable
+# -f disables pathname expansion
+set -euf

--- a/lib/dispatch.sh
+++ b/lib/dispatch.sh
@@ -1,0 +1,48 @@
+# Changes zsh globbing patterns
+unsetopt NO_MATCH >/dev/null 2>&1 || :
+
+# Dispatches calls of commands and arguments
+dispatch ()
+{
+	namespace="$1"     # Namespace to be dispatched
+	arg="${2:-}"       # First argument
+	short="${arg#*-}"  # First argument without trailing -
+	long="${short#*-}" # First argument without trailing --
+
+	# Exit and warn if no first argument is found
+	if [ -z "$arg" ]; then
+		"${namespace}_" # Call empty call placeholder
+		return 1
+	fi
+
+	shift 2 # Remove namespace and first argument from $@
+
+	# Detects if a command, --long or -short option was called
+	if [ "$arg" = "--$long" ];then
+		longname="${long%%=*}" # Long argument before the first = sign
+
+		# Detects if the --long=option has = sign
+		if [ "$long" != "$longname" ]; then
+			longval="${long#*=}"
+			long="$longname"
+			set -- "$longval" "${@:-}"
+		fi
+
+		main_call=${namespace}_option_${long}
+
+
+	elif [ "$arg" = "-$short" ];then
+		main_call=${namespace}_option_${short}
+	else
+		main_call=${namespace}_command_${long}
+	fi
+
+	$main_call "${@:-}" && dispatch_returned=$? || dispatch_returned=$? 
+
+	if [ $dispatch_returned = 127 ]; then
+		"${namespace}_call_" "$namespace" "$arg" # Empty placeholder
+		return 1
+	fi
+
+	return $dispatch_returned
+}

--- a/lib/github-release/cli.sh
+++ b/lib/github-release/cli.sh
@@ -1,0 +1,33 @@
+# Dispatches commands to other msl_(command|option) functions
+githubrelease () ( dispatch githubrelease "${@:-}" )
+
+# Displays help
+githubrelease_command_help ()
+{
+	cat <<-HELP
+'github-release' creates a release for the 'pay-product-page' project and publishes 
+on GitHub. Following conventions, it creates a new GitHub release which gets tied to 
+a new tag created on master. The static version of the product page is generated, 
+bundled and attached to the release.
+
+Usage:
+  github-release [option_list...] 
+  github-release help, -h, --help Displays help for command.
+
+Options:
+  --version          The version
+
+Examples:
+  github-release --version=v1.0.0 publish
+
+HELP
+}
+
+# Option handlers
+githubrelease_option_help        () ( githubrelease_command_help )
+githubrelease_option_h           () ( githubrelease_command_help )
+
+githubrelease_option_version      () ( githubrelease_option_version="$1"; shift; dispatch githubrelease "${@:-}" )
+
+githubrelease_      () ( githubrelease_command_help; return 1 )
+githubrelease_call_ () ( echo "Call '$*' invalid. Try 'github-release --help'"; return 1 )

--- a/lib/github-release/github-release.sh
+++ b/lib/github-release/github-release.sh
@@ -1,0 +1,70 @@
+# Global option defaults
+githubrelease_option_authkey=${GITHUB_TOKEN:-}
+githubrelease_option_version=""
+
+# Location of pay-scripts project relative to this script location
+githubrelease_pay_scripts_path="$(cd "$(dirname "$0")/..";pwd)"
+
+githubrelease_prerequisites ()
+{
+    if ! hash curl 2>/dev/null; then
+        critical "github-release" "curl cannot be found. Make sure curl is installed correctly on your machine: https://curl.haxx.se/"
+        exit 1
+    fi    
+
+    if [ -z "$githubrelease_option_authkey" ]; then
+        critical "github-release" "Make sure the API Key is provided as an env variable GITHUB_TOKEN"
+        exit 1
+    fi
+
+    if [ -z "$githubrelease_option_version" ]; then
+        critical "github-release" "Make sure the release version has been specified with --version"
+        exit 1
+    fi    
+}
+
+githubrelease_generate_package_json_file ()
+{
+cat <<EOF > ./package.json
+{
+  "name": "pay-product-page",
+  "version": "$githubrelease_option_version"
+}
+EOF
+}
+
+githubrelease_new_release ()
+{
+    data="{\"tag_name\": \"$githubrelease_option_version\",\"target_commitish\": \"master\",\"name\": \"$githubrelease_option_version\",\"body\": \"Release of version $githubrelease_option_version\",\"draft\": false,\"prerelease\": false}"
+    response=$(curl --data "$data" https://api.github.com/repos/alphagov/pay-product-page/releases?access_token=$githubrelease_option_authkey)
+
+    inf "github-release" "Release creation: $response"
+
+    upload_url="$(echo "$response" | grep \"upload_url\" || echo )"
+    echo $upload_url | cut -d \" -f 4 | cut -d { -f 1
+}
+
+githubrelease_attach_artifact ()
+{
+    upload_url=$1
+    curl -X POST -H "Authorization:token $githubrelease_option_authkey" -H "Content-Type:application/x-gzip" --data-binary "@pay-product-page-$githubrelease_option_version.tgz" "$upload_url?name=pay-product-page-$githubrelease_option_version.tgz"
+}
+
+githubrelease_command_publish ()
+{
+    githubrelease_prerequisites
+
+    rm -Rf build && bundle exec middleman build && cd build
+    
+    githubrelease_generate_package_json_file
+    tar -cvzf pay-product-page-$githubrelease_option_version.tgz .
+                               
+    upload_url="$(githubrelease_new_release)"
+    
+    if [ -z "$upload_url" ]; then
+        critical "github-release" "Release creation failed."
+        exit 1
+    fi
+    
+    githubrelease_attach_artifact "$upload_url"
+}

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,0 +1,61 @@
+# logging stream (file descriptor 3) defaults to STDERR
+exec 3>&2
+
+# default to show warnings
+verbosity=4
+silent_lvl=0
+crt_lvl=1
+err_lvl=2
+wrn_lvl=3
+inf_lvl=4
+dbg_lvl=5
+
+# Padding
+padding ()
+{
+    s="$1"
+    while [ ${#s} -lt 13 ]; do
+        s=$s' '
+    done
+    printf "$s\n"
+}
+
+# Always prints
+notify ()
+{
+    log $silent_lvl "\033[33;34m$(padding $1) |\033[0m [NOTE] $2";
+} 
+
+critical ()
+{
+    log $crt_lvl "\033[33;34m$(padding $1) |\033[0m \033[33;31m[CRITICAL]\033[0m $2";
+}
+
+error ()
+{
+    log $err_lvl "\033[33;34m$(padding $1) |\033[0m \033[33;31m[ERROR]\033[0m $2";
+}
+
+warn ()
+{
+    log $wrn_lvl "\033[33;34m$(padding $1) |\033[0m \033[33;31m[WARNING]\033[0m $2";
+}
+
+debug ()
+{
+    log $dbg_lvl "\033[33;34m$(padding $1) |\033[0m [DEBUG] $2";
+}
+
+# "info" is already a command
+inf ()
+{
+    log $inf_lvl "\033[33;34m$(padding $1) |\033[0m \033[33;32m[INFO]\033[0m $2";
+} 
+
+log ()
+{
+    if [ $verbosity -ge $1 ]; then
+        # Expand escaped characters, wrap at 70 chars, indent wrapped lines
+        printf "$2\n" >&3
+    fi
+}


### PR DESCRIPTION
The command line script `github-release` allows you to easily build an artifact containing the generated static site and publish it on GitHub in a format that makes it suitable for use as a Node.js dependency.

Using the GitHub API, the script creates a new release from `master` with an associated tag. On your local machine, it then builds a static version of the site (using `middleman`) from your working copy, adds a `package.json` file (which makes it a Node.js module) inside the resulting `build` directory, `tar`s and `gzip`s the `build` directory, then attaches the gzipped tarball as a binary to the release in GitHub, where it appears alongside the source code downloads on the releases page. This artifact is available over HTTPS and can be used as a dependency in a Node.js project.