### PR TITLE
PP-1751 Fixed a typo and used correct markup for headings

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -24,7 +24,7 @@ title: GOV.UK Pay support
 
       <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" target="_top">govuk-pay-support@digital.cabinet-office.gov.uk</a>
 
-      <h2 id="heading-2">New requests</h2>
+      <h2 id="heading-medium">New requests</h2>
       <p>Email us with:</p>
       <ul class="list list-bullet">
           <li>your name, email address and phone number</li>
@@ -33,8 +33,7 @@ title: GOV.UK Pay support
           <li>a link to your online service if you have one</li>
       </ul>
 
-      <h2 id="heading-2">More information</h2>
-      <p>See how use GOV.UK Pay with our <a href="https://gds-payments.gelato.io/docs/versions/1.0.0">technical documentation</a></p>
-
+      <h2 id="heading-medium">More information</h2>
+      <p>See how to use GOV.UK Pay with our <a href="https://gds-payments.gelato.io/docs/versions/1.0.0">technical documentation</a></p>
   </div>
 </div>


### PR DESCRIPTION
- Used `heading-medium` markup instead of `heading-2` for headings.
- Fixed typo