### PR TITLE
PP-2000 Update copy in ‘Who’s using GOV.UK Pay’ section

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -99,7 +99,7 @@
         <div class="grid-row">
             <div class="column-two-thirds">
                 <h2 class="content-section__title">Who’s using GOV.UK Pay</h2>
-                <p>Central government organisations currently using GOV.UK Pay are:</p>
+                <p>GOV.UK Pay is working with:</p>
                 <ul class="list list-bullet">
                     <li>Ministry of Justice</li>
                     <li>Office of the Public Guardian</li>


### PR DESCRIPTION
Changes:

“Central government organisations currently using GOV.UK Pay are:”

… to:

“GOV.UK Pay is working with:”