### PR TITLE
PP-2368 Add register new account link to Getting Started page 

### DIFF
--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -31,8 +31,8 @@
               <span class="task-list-section-number">2.</span> Create an account
           </h2>
           <div class="task-list-items">
-              <p>Test GOV.UK Pay for yourself by sending an email to <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a> and requesting a new account.</p>
-              <p>You can explore the test environment, and use the same account details when you’re ready to go live. You can also connect your service prototype with GOV.UK Pay to test how it works with your users.</p>
+            <p>Test GOV.UK Pay for yourself by <a href="https://selfservice.payments.service.gov.uk/create-service/register">creating an account</a>. You can explore the test environment, and use the same account details when you’re ready to go live.</p>
+              <p>You can also connect your service prototype with GOV.UK Pay to test how it works with your users.</p>
           </div>
 
           <h2 class="task-list-section">


### PR DESCRIPTION
Update text in step 2 of getting started page to include register new account link. 