### PR TITLE
Product page features page: correct some card brand names

### DIFF
--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -40,7 +40,7 @@
                           <li>integrate with existing case management workflows</li>
                           <li>a trusted GOV.UK-branded experience</li>
                           <li>manage access and permissions of your staff users</li>
-                          <li>manage which card brands you want to accept: Visa (including Visa Electron), Mastercard, Maestro, America Express, JCB, Discover, Diners Club, Union Pay</li>
+                          <li>manage which card brands you want to accept: Visa (including Visa Electron), Mastercard, Maestro, American Express, JCB, Discover, Diners Club, UnionPay</li>
                       </ul>
 
                   <h2 class="heading-small">Digital standards</h2>


### PR DESCRIPTION
* “America Express” → “American Express” (add “n” to “America”)
* “Union Pay” → “UnionPay” (remove space between “Union” and “Pay”)