### PR TITLE
Should be sentence case not title case

### DIFF
--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -11,7 +11,7 @@ title: Get started - GOV.UK Pay
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="#main" itemprop="item"><span itemprop="name">Get Started</span></a>
+              <a href="#main" itemprop="item"><span itemprop="name">Get started</span></a>
           </li>
       </ol>
   </nav>


### PR DESCRIPTION
Get started breadcrumb was "Get Started"

We don't use title case for things, we use sentence case. 