### PR TITLE
PP-3119 Fixed status link on main body, and updated footer link with new statuspage.io url

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -93,7 +93,7 @@
                     'Contact' => '/support',
                     'Chat with GOV.UK Pay on Slack' => 'https://ukgovernmentdigital.slack.com/messages/govuk-pay',
                     'Documentation' => 'https://govukpay-docs.cloudapps.digital',
-                    'System status' => 'http://stats.pingdom.com/ejtodj13fqqx'
+                    'System status' => 'https://payments.statuspage.io/'
                   }
               }.each do |header, links|
               %>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -27,7 +27,7 @@ title: Support - GOV.UK Pay
   <div class="grid-row">
     <div class="column-two-thirds">
       <h2 class="heading-medium">Support Process</h2>
-      <p>If you have a problem, first check for known issues on the <a href="#">GOV.UK Pay system status page</a>. Subscribe to get alerts on the progress of any listed issue.</p>
+      <p>If you have a problem, first check for known issues on the <a href="https://payments.statuspage.io/">GOV.UK Pay system status page</a>. Subscribe to get alerts on the progress of any listed issue.</p>
 
       <h3 class="heading-small">During office hours</h3>
       <p>Our office hours are 9.30am to 5.30pm, Monday to Friday. You can email us at <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a></p>


### PR DESCRIPTION
## What

Fixes a broken link (goes nowhere) on the main body of the support page to access the GOV.UK PAY service status, and also updates the footer link to go to the new statuspage.io link