### PR TITLE
BAU - better cookies info page

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -19,7 +19,7 @@ title: Cookies - GOV.UK Pay
 <div class="container">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 id="heading-1">Cookies</h1>
+      <h1 class="heading-large" id="heading-1">Cookies</h1>
       <p class="summary">
         GOV.UK Pay puts small files (known as ‘cookies’)
         on to your computer.
@@ -33,7 +33,7 @@ title: Cookies - GOV.UK Pay
 
       <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
 
-      <p>Find out <a href="http://www.aboutcookies.org/" data-click-events data-click-category="Content" data-click-action="External link clicked">how to manage cookies</a>.</p>
+      <p>Find out <a href="https://ico.org.uk/for-the-public/online/cookies/" data-click-events data-click-category="Content" data-click-action="External link clicked">how to manage cookies</a>.</p>
 
       <h2 class="heading-medium">Session cookie</h2>
 


### PR DESCRIPTION
All GaaP services have been asked to update their cookies pages to link to a more modern Cookies page