### PR TITLE
Use ‘to’ not hyphens for date ranges

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -35,7 +35,7 @@ title: Roadmap - GOV.UK Pay
 
             <p class="panel panel-border-wide">This roadmap is a only a guide and may change from month to month.</p>
 
-            <h2 class="heading-small">July-September 2017</h2>
+            <h2 class="heading-small">July to September 2017</h2>
               <ul class="list list-bullet">
                 <li>Improved onboarding experience</li>
                 <li>Self service account creation and team management</li>
@@ -46,7 +46,7 @@ title: Roadmap - GOV.UK Pay
                 <li>Finalised contract for non-Crown bodies</li>
               </ul>
       
-      <h2 class="heading-small">October-December 2017</h2>
+      <h2 class="heading-small">October to December 2017</h2>
               <ul class="list list-bullet">
                 <li>Improved settlement reporting for bank reconciliation</li>
                 <li>Direct Debit - Part 1</li>
@@ -55,7 +55,7 @@ title: Roadmap - GOV.UK Pay
                 <li><a href="https://gds.blog.gov.uk/2017/09/12/local-government-pay/"  data-click-events data-click-category="Content" data-click-action="External link clicked">Run a pilot with local authorities</a></li>
               </ul>
       
-            <h2 class="heading-small">January-March 2018</h2>
+            <h2 class="heading-small">January to March 2018</h2>
               <ul class="list list-bullet">
                 <li>Reporting across multiple services</li>
                 <li>Direct Debit - Part 2</li>


### PR DESCRIPTION
> Use ‘to’ instead of a dash or slash in date ranges. ‘To’ is quicker to read than a dash, and it’s easier for screen readers.

– https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges
