### PR TITLE
Remove reference to "central government" on get started page

### DIFF
--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -27,7 +27,7 @@ title: Get started - GOV.UK Pay
               <span class="task-list-section-number">1.</span> Check GOV.UK Pay is right for you
             </h2>
             <div class="task-list-items">
-              <p>GOV.UK&nbsp;Pay should be suitable for any government or public sector organisation with a new or existing digital service that wants to take card payments online.</p>
+              <p>GOV.UK&nbsp;Pay should be suitable for any government or public sector organisation that wants to take card payments online.</p>
               <p>Review GOV.UK Pay’s <a href="/features" data-click-events data-click-category="Content" data-click-action="Internal link clicked">top features and roadmap</a> and decide if it meets your service’s needs.</p>
             </div>
 

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -27,7 +27,7 @@ title: Get started - GOV.UK Pay
               <span class="task-list-section-number">1.</span> Check GOV.UK Pay is right for you
             </h2>
             <div class="task-list-items">
-              <p>If you are a central government organisation with a new or existing digital service, and want to take card payments online, then GOV.UK&nbsp;Pay should be suitable for you.</p>
+              <p>If you are a government organisation with a new or existing digital service, and want to take card payments online, then GOV.UK&nbsp;Pay should be suitable for you.</p>
               <p>Review GOV.UK Pay’s <a href="/features" data-click-events data-click-category="Content" data-click-action="Internal link clicked">top features and roadmap</a> and decide if it meets your service’s needs.</p>
             </div>
 

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -27,7 +27,7 @@ title: Get started - GOV.UK Pay
               <span class="task-list-section-number">1.</span> Check GOV.UK Pay is right for you
             </h2>
             <div class="task-list-items">
-              <p>If you are a government organisation with a new or existing digital service, and want to take card payments online, then GOV.UK&nbsp;Pay should be suitable for you.</p>
+              <p>GOV.UK&nbsp;Pay should be suitable for any government or public sector organisation with a new or existing digital service that wants to take card payments online.</p>
               <p>Review GOV.UK Pay’s <a href="/features" data-click-events data-click-category="Content" data-click-action="Internal link clicked">top features and roadmap</a> and decide if it meets your service’s needs.</p>
             </div>
 


### PR DESCRIPTION
now just says government organisations