### PR TITLE
Update product page so it's less specific to central govt

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -157,7 +157,7 @@
               <p class="">“I’ve just had the first view of [GOV.UK&nbsp;Pay] integrated with our service. It is a really good product. We have integrated it in just 2 weeks which is astonishing and really speaks volumes about [how] well you have set the service up…”</p>
               <p>– Service manager; UK Visas and Immigration, Home Office</p>
             </div>
-            <p>GOV.UK&nbsp;Pay is available to all central government organisations. We are running limited pilots with some local authorities.</p>
+            <p>GOV.UK&nbsp;Pay is available to all government and public sector organisations, including central government, local government and the NHS.</p>
           </div>
       </div>
     </div>


### PR DESCRIPTION
final sentence altered to make it clear that GOV.UK Pay is open to local govt, NHS and other public sector orgs