### PR TITLE
Change “Stratford-upon-Avon” to “Stratford-on-Avon” in alt text

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -156,7 +156,7 @@
             <img class="content-section__image partner-logo" src="/pay-product-page/images/logos/ccc.png" alt="Canterbury City Council" />
             <img class="content-section__image partner-logo partner-logo-smaller" src="/pay-product-page/images/logos/kcc.png" alt="Kent County Council" />
             <img class="content-section__image partner-logo" src="/pay-product-page/images/logos/disclosure-scotland.png" alt="Disclosure Scotland" />
-            <img class="content-section__image partner-logo" src="/pay-product-page/images/logos/stratford.png" alt="Stratford-upon-Avon District Council" />
+            <img class="content-section__image partner-logo" src="/pay-product-page/images/logos/stratford.png" alt="Stratford-on-Avon District Council" />
             <img class="content-section__image partner-logo" src="/pay-product-page/images/logos/nhs.png" alt="NHS" />
           </div>
         </div>


### PR DESCRIPTION
While the town is called Statford-upon-Avon, the district (and the district council) is named Stratford-on-Avon