### PR TITLE
update roadmap for q2 2018

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -39,23 +39,32 @@ title: Roadmap - GOV.UK Pay
               <ul class="list list-bullet">
                 <li>Operability improvements: Introduce AWS ECS for application deployments - DONE</li>
                 <li>Direct Debit: One-off payments - DONE</li>
-                <li>Self service payments: ad-hoc payments for offline services - DONE</li>
+                <li>Self service payment links: ad-hoc payments for offline services - DONE</li>
                 <li>Refunds reporting and improved payment states - DONE</li>
                 <li>3DSecure for EPDQ and Smartpay - DONE</li>
               </ul>
       
             <h2 class="heading-small">April to June 2018</h2>
               <ul class="list list-bullet">
-                <li>Operability, support & better use of data</li>
+                <li>Improving the deployment pipeline: contract and browser testing</li>
                 <li>Direct Debit: recurring 'on demand' payments</li>
               </ul>
 
-            <h2 class="heading-small">July 2018 to March 2019</h2>
+            <h2 class="heading-small">July to September 2018</h2>
               <ul class="list list-bullet">
+                 <li>Operability, support and scaling reporting performance</li>
+                 <li>Payment experience and API improvements (payment pages in Welsh, surcharging for corporate credit cards, delayed capture of payment, pre-populate billing address and email, refund email to paying users)</li>
+              </ul>
+             
+            <h2 class="heading-small">October to December 2018</h2>
+              <ul class="list list-bullet">
+                 <li>Reporting for telephone payments</li>
+                 <li>Automated onboarding for services</li>
+               </ul>
+                
+            <h2 class="heading-small">2019</h2>
                 <li>Self service payments: get invoices paid online</li>
-                <li>Reporting for telephone payments</li>
                 <li>Notifications and webhooks for Direct Debit and phone payments</li>
-                <li>Payment experience and API improvements (Pre-populate billing address and email, refund email to paying users, add fields for financially regulated organisations)</li>
                 <li>New information architecture for multiple payment types, efficiency improvements to our connector microservice</li>
                 <li>Reporting across multiple accounts and payment types</li>
                 <li>Refined permissions for staff users, create platform admin console</li>


### PR DESCRIPTION
IN - refund email, since we should just do it 
OUT - explicit reference to having a centrally procured card provider, until that's agreed with GBS