### PR TITLE
Change "self-service payments" to "payment links"

### DIFF
--- a/source/self-service-payments.html.erb
+++ b/source/self-service-payments.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Self service payments - GOV.UK Pay
+title: GOV.UK Pay payment links
 ---
 
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
@@ -11,7 +11,7 @@ title: Self service payments - GOV.UK Pay
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="#main" itemprop="item"><span itemprop="name">Self service payments</span></a>
+              <a href="#main" itemprop="item"><span itemprop="name">Payment links</span></a>
           </li>
       </ol>
   </nav>
@@ -19,7 +19,7 @@ title: Self service payments - GOV.UK Pay
   <div class="grid-row">
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">
-        Self service payments
+        Payment links
       </h1>
 
       <p>Payment links allow your service to receive online payments from your users. You don’t need to have a digital service to use payment links.</p>
@@ -29,7 +29,7 @@ title: Self service payments - GOV.UK Pay
       <h2 class="heading-medium">Benefits of using online payments</h2>
 
       <p>Online payments are 4 times more cost effective than offline methods, like cheques, money orders and cash payments.</p>
-      <p>By using self service payments your service can:</p>
+      <p>By using payment links your service can:</p>
 
       <ul class="list list-bullet"> 
         <li>speed up payment processes - you’ll be able to receive payments and issue refunds much quicker</li>
@@ -50,7 +50,7 @@ title: Self service payments - GOV.UK Pay
 
       <img class="content-section__image" src="/pay-product-page/images/self-service-payments-flow.svg" alt="Example of the payment amount and confirmation pages of the payment link user journey.">
 
-      <h2 class="heading-medium">Get started with self service payments</h2>
+      <h2 class="heading-medium">Get started with payment links</h2>
 
       <p>Use our <a href="/getstarted">guide to getting started</a> to create an account. Or <a href="/support">contact the team</a> for more information.</p>
     </div>


### PR DESCRIPTION
After discussions with @mpwoods and @karlchillmaid, our alignment consensus is that we should use the term "payment links" exclusively (as opposed to "self-service payments") on the features page and in the documentation.

Worth noting that the actual URL still contains the term "selfservice" and so do several of the images used. Probably other instances, too. 