### PR TITLE
Add line to support section to indicate what GOV.UK Pay support is for

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -22,7 +22,7 @@ title: Support - GOV.UK Pay
       <h1 class="heading-large">Support</h1>
       <p>GOV.UK Pay is built and supported 24/7 by a full-time team at the Government Digital Service. The service manager is Till Wirth.</p>
       <p>Follow our <a href="/getstarted/" data-click-events data-click-category="Content" data-click-action="Internal link clicked">guide to getting started</a> to create an account.</p>
-      <p>GOV.UK Pay's support is for government services, and does not provide support for individual members of the public paying for services. If you are a member of the public experiencing technical difficulties paying for a specific service, please contact that service's support directly.</p> 
+      <p>GOV.UK Pay’s support is for government services, and does not provide support for individual members of the public paying for services. If you are a member of the public experiencing technical difficulties paying for a specific service, please contact that service’s support directly.</p> 
     </div>
   </div>
   <div class="grid-row">

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -32,7 +32,6 @@ title: Support - GOV.UK Pay
 
       <h3 class="heading-small">During office hours</h3>
       <p>Our office hours are 9.30am to 5.30pm, Monday to Friday. You can email us at <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" data-click-events data-click-category="Content" data-click-action="Email link clicked">govuk-pay-support@digital.cabinet-office.gov.uk</a></p>
-      <p>Or chat with us on our cross-government Slack channel: <a href="https://ukgovernmentdigital.slack.com/messages/govuk-pay" data-click-events data-click-category="Content" data-click-action="External link clicked">https://ukgovernmentdigital.slack.com/messages/govuk-pay</a></p>
 
       <h3 class="heading-small">Out of hours support</h3>
       <p>We offer 24 hour online support for critical incidents affecting live production services. We have different response times depending on whether the problem you want to report is an emergency.</p>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -22,6 +22,7 @@ title: Support - GOV.UK Pay
       <h1 class="heading-large">Support</h1>
       <p>GOV.UK Pay is built and supported 24/7 by a full-time team at the Government Digital Service. The service manager is Till Wirth.</p>
       <p>Follow our <a href="/getstarted/" data-click-events data-click-category="Content" data-click-action="Internal link clicked">guide to getting started</a> to create an account.</p>
+      <p>GOV.UK Pay's support is for government services, and does not provide support for individual members of the public paying for services. If you are a member of the public experiencing technical difficulties paying for a specific service, please contact that service's support directly.</p> 
     </div>
   </div>
   <div class="grid-row">


### PR DESCRIPTION
Starter for ten, per discussion with @katiebates and @alexbishop1 about numerous support tickets received from members of the public.