### PR TITLE
Remove duplicate “ - GOV.UK Pay” from page titles

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Cookies - GOV.UK Pay
+title: Cookies
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Features - GOV.UK Pay
+title: Features
 ---
 
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Get started - GOV.UK Pay
+title: Get started
 ---
 
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/payment-links.html.erb
+++ b/source/payment-links.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Payment links - GOV.UK Pay
+title: Payment links
 ---
 
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Privacy notice - GOV.UK Pay
+title: Privacy notice
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Roadmap - GOV.UK Pay
+title: Roadmap
 ---
 
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Support - GOV.UK Pay
+title: Support
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">


### PR DESCRIPTION
Each page title defintion included the suffix “ - GOV.UK Pay” (e.g. “Features — GOV.UK”) but the main layout template already added this, resulting in displayed page titles like “Features - GOV.UK Pay - GOV.UK Pay”.

This change removes “ - GOV.UK Pay” from each page title definition so that the displayed titles end up like “Features - GOV.UK Pay”. The main index page remains unchaged as “GOV.UK Pay”.