### PR TITLE
BAU - aria hidden boolean should be set by JS

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -64,7 +64,7 @@
           Menu
         </label>
 
-        <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
+        <nav id="navigation" class="header__navigation" aria-label="Top Level Navigation" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
           <ul>
             <%
               {


### PR DESCRIPTION
so that if the page opens on mobile - the navigation is
read out by screen readers, then navigation.js kicks in
and toggles the menu toggle and changes aria-hidden to true.