### PR TITLE
tiny tweaks to blue badge page

### DIFF
--- a/source/blue-badge-scheme.html.erb
+++ b/source/blue-badge-scheme.html.erb
@@ -47,13 +47,14 @@ title: Blue Badge scheme - GOV.UK Pay
         <p>GOV.UK Pay processes debit and credit card transactions.</p>
         <p>All payments will be sent to the bank account you specify within the GOV.UK Pay configuration.</p>
         <p>Payments are processed instantly. They are paid into your account in batches 2 working days after the payment is made. You’ll be able to see payment information in real-time on your dashboard.</p>
+        <p>If you need to wait until a Blue Badge application has been agreed before charging users, you can use <a href="https://www.payments.service.gov.uk/payment-links">payment links</a>.</p>
         <p>Payments can be easily reconciled. Every payment will be assigned a unique application ID by the Blue Badge service. GOV.UK Pay also assigns a unique ID to every payment. It’s best to refer to the GOV.UK Pay ID when communicating with the <a href="/support">GOV.UK Pay support team</a>.</p>
         <p>Your service cannot take cash or cheque payments using GOV.UK Pay.</p>
         <p>We do not currently offer integrated reporting for phone payments. We’re carrying out a pilot with one service to see if this is something we can offer in future.</p>
 
         <h2 class="heading-medium">Documentation and support</h2>
         <p>GOV.UK Pay provides <a href="https://docs.payments.service.gov.uk/#gov-uk-pay-documentation">detailed documentation</a>. This documentation is mainly written for teams that are building their own API integration with GOV.UK Pay. You only need to do this if you want to automate your reporting and refunds process.</p>
-        <p>The Blue Badge service has been designed to be as self-serve as possible. You can <a href="/getstarted">sign up for a test account</a> and try it for yourself.</p>
+        <p>GOV.UK Pay is designed to be as self-serve as possible. You can <a href="/getstarted">sign up for a test account</a> and try it for yourself.</p>
         <p>You can also <a href="/support">contact the GOV.UK Pay team</a> if you have any questions or feedback.</p>
     </div>
 </div>


### PR DESCRIPTION
- increase awareness of using payment links if payment isn't taken upfront 
- changes "The Blue Badge service has been designed to be as self-serve as possible." to  "GOV.UK Pay is designed to be as self-serve as possible."