### PR TITLE
update roadmap for Q4

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -34,35 +34,34 @@ title: Roadmap
             <p>Here’s a list of the new functionality we’re planning to offer through GOV.UK&nbsp;Pay.</p>
 
             <p class="panel panel-border-wide">This roadmap is a only a guide and may change from month to month.</p>
-
-            <h2 class="heading-small">July to September 2018</h2>
-              <ul class="list list-bullet">
-                 <li>Variable Direct Debit - contact us if you want to be a beta partner</li>
-                 <li>Scale to take high volumes of payments</li>
-                 <li>Payment pages in Welsh language</li>
-                 <li>Delayed capture of payments</li>
-                 <li>Refund email to paying users</li>
-                 <li>Search for refunds in our API</li>
-                 <li>Search transactions by cardholder name and last 4 card numbers on our admin site and API</li>
-                 <li>Search transactions by first 6 card numbers via our API</li>
-              </ul>
              
             <h2 class="heading-small">October to December 2018</h2>
               <ul class="list list-bullet">
                  <li>Collecting billing and email address from paying users will be optional</li>
-                 <li>Billing address and email address can be pre-populated</li>
-                 <li>Edit email addresses of paying users and resend payment confirmation emails</li> 
-                 <li>Reporting for telephone payments</li>
+                 <li>Apply surcharges to corporate credit or debit cards</li>
+                 <li>Allow services to use their own unsuccessful payment screens</li> 
+                 <li>Integrate with a new payment service provider for card payments (Stripe)</li>
                  <li>Quicker and easier onboarding for services</li>
                  <li>A card processing contract that GDS procures - so you don’t need to bring your own contract</li> 
                </ul>
+      
+            <h2 class="heading-small">January to March 2019</h2>
+              <ul class="list list-bullet">
+                 <li>Add functionality to our Direct Debit service</li>
+                 <li>Support for Apple Pay and Google Pay</li>
+                 <li>Reporting for telephone payments</li>
+                 <li>Maximise conversion rates on our hosted payment pages</li>
+                 <li>Apply custom branding to payment links</li> 
+                 <li>Payment links in Welsh language</li> 
+                 <li>Payment and refund confirmation emails in Welsh language</li>
+                 <li>Associate structured data (metadata) with transactions</li> 
+                <li>Billing address and email address can be pre-populated</li>
+               </ul>
                 
-            <h2 class="heading-small">2019</h2>
-                <li>Add functionality to our Direct Debit service</li>
-                <li>Reporting across multiple accounts and payment types</li>
+            <h2 class="heading-small">Later in 2019</h2>
                 <li>Repeat card payments</li>
+                <li>Reporting across multiple accounts and payment types</li>
                 <li>Get invoices paid online</li>
-                <li>Support for eWallets</li>
                 <li>Support for Pay via Bank Account (PSD2)</li>
                 <li>Enable services to publish and sell from a product catalogue</li>
                 <li>Foreign currency and language support</li>


### PR DESCRIPTION
includes some updates to what we've done this quarter and a new section for next quarter. 
- i've deleted july-september 2018 as the information is broadly available on our features page and is in the tech docs, and keeping it there risks pushing the relevant info too far down the page. 
- have veered towards an optimistic list for next quarter as more likely to get feedback on features, and retrospectively deleting things we haven't done doesn't seem to have been a problem so far. 
- not sure if Stripe + Apple/Google pay should be mentioned explicitly at this stage. @tillwirth to confirm.