### PR TITLE
v2 update roadmap for Q4

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -34,40 +34,41 @@ title: Roadmap
             <p>Here’s a list of the new functionality we’re planning to offer through GOV.UK&nbsp;Pay.</p>
 
             <p class="panel panel-border-wide">This roadmap is a only a guide and may change from month to month.</p>
-
-            <h2 class="heading-small">July to September 2018</h2>
-              <ul class="list list-bullet">
-                 <li>Variable Direct Debit - contact us if you want to be a beta partner</li>
-                 <li>Scale to take high volumes of payments</li>
-                 <li>Payment pages in Welsh language</li>
-                 <li>Delayed capture of payments</li>
-                 <li>Refund email to paying users</li>
-                 <li>Search for refunds in our API</li>
-                 <li>Search transactions by cardholder name and last 4 card numbers on our admin site and API</li>
-                 <li>Search transactions by first 6 card numbers via our API</li>
-              </ul>
              
             <h2 class="heading-small">October to December 2018</h2>
               <ul class="list list-bullet">
                  <li>Collecting billing and email address from paying users will be optional</li>
-                 <li>Billing address and email address can be pre-populated</li>
-                 <li>Edit email addresses of paying users and resend payment confirmation emails</li> 
-                 <li>Reporting for telephone payments</li>
+                 <li>Apply surcharges to corporate credit or debit cards</li>
+                 <li>Allow services to use their own unsuccessful payment screens</li> 
                  <li>Quicker and easier onboarding for services</li>
-                 <li>A card processing contract that GDS procures - so you don’t need to bring your own contract</li> 
+                 <li>A card processing contract that GDS procures - so services don’t need to bring their own contract</li> 
                </ul>
-                
-            <h2 class="heading-small">2019</h2>
-                <li>Add functionality to our Direct Debit service</li>
-                <li>Reporting across multiple accounts and payment types</li>
+      
+            <h2 class="heading-small">January to March 2019</h2>
+              <ul class="list list-bullet">
+                 <li>Add functionality to our Direct Debit service</li>
+                 <li>Support for Apple Pay and Google Pay</li>
+                 <li>Reporting for telephone payments</li>
+                 <li>Improve conversion rates on our payment pages</li>
+                 <li>Apply custom branding to payment links</li> 
+                 <li>Payment links in Welsh language</li> 
+                 <li>Payment and refund confirmation emails in Welsh language</li>
+                 <li>Associate arbitrary structured metadata with transactions (for example, fund and ledger codes)</li> 
+                 <li>Billing address and email address can be pre-populated</li>
+               </ul>
+      
+            <h2 class="heading-small">Later in 2019</h2>
+              <ul class="list list-bullet">
                 <li>Repeat card payments</li>
+                <li>Reporting across multiple accounts and payment types</li>
                 <li>Get invoices paid online</li>
-                <li>Support for eWallets</li>
+                <li>Support for other eWallets</li>
                 <li>Support for Pay via Bank Account (PSD2)</li>
                 <li>Enable services to publish and sell from a product catalogue</li>
                 <li>Foreign currency and language support</li>
               </ul>
-
+     
+      
             <h2 class="heading-medium">Queries and suggestions</h2>
             <p>If you want to find out more about these features, or have some needs that GOV.UK Pay isn’t yet meeting, please get in touch with us by emailing <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" data-click-events data-click-category="Content" data-click-action="Email link clicked">govuk-pay-support@digital.cabinet-office.gov.uk</a> or chat with us in our <a href="https://ukgovernmentdigital.slack.com/messages/govuk-pay" data-click-events data-click-category="Content" data-click-action="External link clicked">cross-government Slack channel</a>.</p>
     </div>


### PR DESCRIPTION
includes some updates to what we've done this quarter and a new section for next quarter.

- i've deleted july-september 2018 as the information is broadly available on our features page and is in the tech docs, and keeping it there risks pushing the relevant info too far down the page.
- have veered towards an optimistic list for next quarter as more likely to get feedback on features, and retrospectively deleting things we haven't done doesn't seem to have been a problem so far.