### PR TITLE
Breadcrumbs: replace “Components” with “GOV.UK services”

### DIFF
--- a/source/blue-badge-scheme.html.erb
+++ b/source/blue-badge-scheme.html.erb
@@ -5,7 +5,7 @@ title: Blue Badge scheme - GOV.UK Pay
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -5,7 +5,7 @@ title: Cookies
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
   <ol itemscope itemtype="http://schema.org/BreadcrumbList">
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+      <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/direct-debit.html.erb
+++ b/source/direct-debit.html.erb
@@ -5,7 +5,7 @@ title: Direct Debit on GOV.UK Pay
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -5,7 +5,7 @@ title: Features
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -5,7 +5,7 @@ title: Get started
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/pay-product-page/stylesheets/modules/_breadcrumbs.scss
+++ b/source/pay-product-page/stylesheets/modules/_breadcrumbs.scss
@@ -19,7 +19,7 @@
  * <nav class="breadcrumbs" aria-label="Breadcrumbs">
  *   <ol itemscope itemtype="http://schema.org/BreadcrumbList">
  *     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
- *       <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+ *       <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
  *     </li>
  *     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
  *       <a href="#main" itemprop="item"><span itemprop="name">Product Page</span></a>

--- a/source/payment-links.html.erb
+++ b/source/payment-links.html.erb
@@ -5,7 +5,7 @@ title: Payment links
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -5,7 +5,7 @@ title: GOV.UK Pay’s Payment Service Provider
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -5,7 +5,7 @@ title: Privacy notice
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
   <ol itemscope itemtype="http://schema.org/BreadcrumbList">
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+      <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -5,7 +5,7 @@ title: Roadmap
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/security.html.erb
+++ b/source/security.html.erb
@@ -5,7 +5,7 @@ title: Security
   <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
       <ol itemscope itemtype="http://schema.org/BreadcrumbList">
           <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+              <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
           </li>
           <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -5,7 +5,7 @@ title: Support
 <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
   <ol itemscope itemtype="http://schema.org/BreadcrumbList">
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+      <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
     </li>
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="/" itemprop="item"><span itemprop="name">GOV.UK Pay</span></a>


### PR DESCRIPTION
In the breadcrumbs on the subpages, replace “Components” linking to https://www.gov.uk/service-toolkit with “GOV.UK services” linking to https://www.gov.uk/service-toolkit#gov-uk-services