### PR TITLE
PP-4658 - cookie banner wasnt showing because the script loaded too soon

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -21,7 +21,6 @@
 
     <!-- Google Search Console ownership verification -->
     <meta name="google-site-verification" content="niWnSqImOWz6mVQTYqNb5tFK8HaKSB4b3ED4Z9gtUQ0" />
-    <%= javascript_include_tag "application.prebundled.min.js" %>
     <% if config.analytics != '' %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -156,5 +155,6 @@
         </div>
       </div>
     </footer>
+    <%= javascript_include_tag "application.prebundled.min.js" %>
   </body>
 </html>


### PR DESCRIPTION
Move script to bottom so that DOM exists when it executes