### PR TITLE
Manually include sass gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'middleman', '>= 4.1.14'
 gem 'middleman-livereload', '>= 3.4.6'
 gem "middleman-sprockets", ">= 4.1.0"
+gem 'sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     contracts (0.13.0)
-    dotenv (2.7.2)
+    dotenv (2.7.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -93,6 +93,11 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -116,8 +121,9 @@ DEPENDENCIES
   middleman (>= 4.1.14)
   middleman-livereload (>= 3.4.6)
   middleman-sprockets (>= 4.1.0)
+  sass
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Middleman has updated to sassc but sprockets hasnt, so need to include
sass gem manually in the meantime

see this thread - https://github.com/middleman/middleman-sprockets/issues/132