### PR TITLE
Add Github action for generating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: new-release
+
+on: push
+
+jobs:
+  build:
+    name: generate-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.x'
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: deps
+        run: |
+          gem install bundler
+          bundle install
+          npm install
+      - name: build
+        run: bundle exec middleman build
+      - name: release
+        if: github.ref == 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./bin/github-release --version "${GITHUB_SHA::7} publish"

--- a/lib/github-release/github-release.sh
+++ b/lib/github-release/github-release.sh
@@ -54,7 +54,7 @@ githubrelease_command_publish ()
 {
     githubrelease_prerequisites
 
-    rm -Rf build && bundle exec middleman build && cd build
+    test ! -d build && bundle exec middleman build && cd build
     
     githubrelease_generate_package_json_file
     tar -cvzf pay-product-page-$githubrelease_option_version.tgz .


### PR DESCRIPTION
This should automatically generate a Github release whenever code gets
merged to master. The release name is based on the SHA of the commit.