### PR TITLE
Use CI token for repository dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Trigger pay-frontend
         if: github.ref == 'refs/heads/master'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_AUTH_TOKEN }}
         run: |
           curl -XPOST \
             -H "Accept: application/vnd.github.everest-preview+json" \
             -H "Content-Type: application/json" \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -u "alphagov-pay-ci:${GITHUB_TOKEN}" \
             --data '{"event_type": "product-page-release"}' \
             https://api.github.com/repos/alphagov/pay-frontend/dispatches


### PR DESCRIPTION
To send a dispatch event we need to use credentials that have access to
the destination repo, so I've added the CI github token as a secret to
the repo.