### PR TITLE
Append SHA to semantic version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./bin/github-release --version "${GITHUB_SHA::7}" publish
+          ./bin/github-release --version "3.0-${GITHUB_SHA::7}" publish
       - name: Trigger pay-frontend
         if: github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION
NPM requires that all packages follow semantic versioning conventions.
Since we want to use the commit SHA as our "version", we can append this
to an actual version. See https://stackoverflow.com/questions/46967493/npm-init-and-using-non-semver-standards