### PR TITLE
PP-5653 - Remove payment service links

### DIFF
--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -65,9 +65,9 @@ title: Accessibility statement for GOV.UK Pay
       <ul class="list list-bullet">
         <li>our main website platform, available at <a href="https://www.payments.service.gov.uk">https://www.payments.service.gov.uk</a></li>
         <li>our payments account platform, available at <a href="https://selfservice.payments.service.gov.uk">https://selfservice.payments.service.gov.uk</a></li>
-        <li>our credit card payment platform at <a href="https://card.payments.service.gov.uk">https://card.payments.service.gov.uk</a></li>
-        <li>our direct debit payments platform at <a href="https://directdebit.payments.service.gov.uk">https://directdebit.payments.service.gov.uk</a></li>
-        <li>our payment links platform at <a href="https://products.payments.service.gov.uk">https://products.payments.service.gov.uk</a></li>
+        <li>our credit card payment platform at https://card.payments.service.gov.uk</li>
+        <li>our direct debit payments platform at https://directdebit.payments.service.gov.uk</li>
+        <li>our payment links platform at https://products.payments.service.gov.uk</li>
       </ul>
 
       <h2 class="heading-medium">What we’re doing to improve accessibility</h2>


### PR DESCRIPTION
We can't link to them without a payment token so it 404s which is messy
so for now removing the link as there seems to be a requirement that we
have to include the link.