### PR TITLE
REP-295: Fix github release script

### DIFF
--- a/lib/github-release/github-release.sh
+++ b/lib/github-release/github-release.sh
@@ -54,8 +54,9 @@ githubrelease_command_publish ()
 {
     githubrelease_prerequisites
 
-    test ! -d build && bundle exec middleman build && cd build
-    
+    test ! -d build && bundle exec middleman build
+
+    cd build
     githubrelease_generate_package_json_file
     tar -cvzf pay-product-page-$githubrelease_option_version.tgz .
                                


### PR DESCRIPTION
The script should always `cd build` before packaging.