### PR TITLE
PP-5950 Revert instructions for releasing static copy of site

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,20 @@ Look at the CSS for the individual components for usage examples and notes.
 - [Skip Link](source/stylesheets/modules/_skip-link.scss)
 - [Sub Navigation](source/stylesheets/modules/_sub-navigation.scss)
 
-## Releasing the Product Pages
+## Releasing a Static Copy of the Site
 
-There is now a semi-automated process for getting a new build of the product pages into pay-frontend, orchestrated by GitHub Actions.
-When a change is merged to master, the following happens:
+The command line script `github-release` allows you to easily build an artifact containing the generated static site and publish it on GitHub in a format that makes it suitable for use as a Node.js dependency.
 
-- The Action defined in `.github/workflows/release.yml` will automatically build and publish a new release
-- The Action sends a trigger to pay-frontend
-- An Action defined in pay-frontend under `.github/workflows/product-page.yml` acts on this trigger and bumps the `pay-product-page` version in `package.json`
-- The Action then raises a PR in pay-frontend with the changes to `package.json` and `package-lock.json`
+Using the GitHub API, the script creates a new release from `master` with an associated tag. On your local machine, it then builds a static version of the site (using `middleman`) from your working copy, adds a `package.json` file (which makes it a Node.js module) inside the resulting `build` directory, `tar`s and `gzip`s the `build` directory, then attaches the gzipped tarball as a binary to the release in GitHub, where it appears alongside the source code downloads on the releases page. This artifact is available over HTTPS and can be used as a dependency in a Node.js project.
+
+In order to run the script, you need to declare an environment variable called `GITHUB_TOKEN` containing your GitHub authentication token:
+
+`GITHUB_TOKEN=xxx`
+
+Then you can run the script:
+
+`bin/github-release --version 1.0.1 publish`
+
+The `--version` argument specifies the version of the new release (pick something sensible based on the previous releases). This version number is used for the release version, tag name, `version` property in the `package.json` and as part of the file name for the binary.
+
+The script is bash and has no dependencies other than `curl` and those necessary for `middleman`.


### PR DESCRIPTION
We can no longer use GitHub Actions to release the product page, so restore the old instructions for releasing a static version of the site.