### PR TITLE
PP-5977 Remove Google Analytics Pay Product

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -26,7 +26,6 @@ title: Cookies
       <ul class="govuk-list govuk-list--bullet">
         <li>secure your payment session</li>
         <li>remember the notifications you’ve seen so we don’t show them again</li>
-        <li>measure how you use the website so it can be updated and improved based on your needs</li>
       </ul>
 
       <p class="govuk-body">Cookies are also used to remember any government users who’ve signed in to our payments admin tool.</p>
@@ -74,40 +73,6 @@ title: Cookies
             <th class="govuk-table__cell govuk-table__head" scope="row">seen_cookie_message</th>
             <td class="govuk-table__cell">Saves a message to let us know that you have seen our cookie message</td>
             <td class="govuk-table__cell">1 month</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2 class="govuk-heading-m">Universal analytics</h2>
-      <p class="govuk-body">These cookies track how many people have visited GOV.UK&nbsp;Pay.</p>
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header govuk-!-width-one-third" scope="col">Name</th>
-            <th class="govuk-table__header" scope="col">Purpose</th>
-            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Expires</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__cell govuk-table__head" scope="row">_ga</th>
-            <td class="govuk-table__cell">This helps us count how many people visit GOV.UK Pay by tracking if you’ve visited before</td>
-            <td class="govuk-table__cell">2 years</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__cell govuk-table__head" scope="row">_gid</th>
-            <td class="govuk-table__cell">This helps us count how many people visit GOV.UK Pay by tracking if you’ve visited before</td>
-            <td class="govuk-table__cell">1 day</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__cell govuk-table__head" scope="row">_gat</th>
-            <td class="govuk-table__cell">This helps us count how many people visit GOV.UK Pay by tracking if you’ve visited before</td>
-            <td class="govuk-table__cell">1 minute</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__cell govuk-table__head" scope="row">_gat_govuk_shared</th>
-            <td class="govuk-table__cell">This helps us count how many people visit GOV.UK Pay by tracking if you’ve visited before</td>
-            <td class="govuk-table__cell">1 minute</td>
           </tr>
         </tbody>
       </table>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -22,7 +22,11 @@
 
     <!-- Google Search Console ownership verification -->
     <meta name="google-site-verification" content="niWnSqImOWz6mVQTYqNb5tFK8HaKSB4b3ED4Z9gtUQ0" />
-    <% if config.analytics != '' %>
+    <% 
+    # The code below is set to false so as not to enable Google Analytics for ICO compliance. Re-enable when opt-in as been done
+    # Original code is <% if config.analytics != '' %>
+    %>
+    <% if false %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Description:
- Because of ICO compliance we can't store non-essential cookies so we have disabled Google Analytics as a temporary measure.
- When opt-in is enabled then we can renable Google Analytics
- Layout page has been updated to remove the 'Universal Analytics' section