### PR TITLE
PP-5977 Update product pages cookie information

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -24,7 +24,7 @@
     <meta name="google-site-verification" content="niWnSqImOWz6mVQTYqNb5tFK8HaKSB4b3ED4Z9gtUQ0" />
     <% 
     # The code below is set to false so as not to enable Google Analytics for ICO compliance. Re-enable when opt-in as been done
-    # Original code is <% if config.analytics != '' %>
+    # Original code is - if config.analytics != '' -
     %>
     <% if false %>
     <script>

--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -58,7 +58,7 @@ title: Privacy notice
       </div>
       <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l" id="heading-1">Privacy notice</h1>
-      <p class="govuk-body-l">Last updated: 21 February 2019</p>
+      <p class="govuk-body-l">Last updated: 19 December 2019</p>
 
       <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
       <p class="govuk-body">GOV.UK Pay is a payments service that’s built and maintained by the Government Digital Service, part of the Cabinet Office (“GDS”, “we”, “us”, “our”). We and other public sector organisations use GOV.UK Pay to take payments online and process them efficiently. To do that, we collect, process and store certain data about you.</p>
@@ -106,13 +106,6 @@ title: Privacy notice
         <li>the reference number of the government organisation</li>
       </ul>
 
-      <h3 class="govuk-heading-s">Device information</h3>
-      <p class="govuk-body">We will collect data that includes:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>usage data, like IP addresses and technical details of the payer’s connection </li>
-        <li>equipment, like the phone or laptop used to make the payment</li>
-      </ul>
-
       <h2 class="govuk-heading-m" id="what-data-we-need-from-staff-users">What data we need from staff users</h2>
       <p class="govuk-body">We also collect data about authorised staff users.</p>
 
@@ -130,13 +123,6 @@ title: Privacy notice
       <p class="govuk-body">We will collect data that includes:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>details about the staff user’s role - for example, what rights a user has to view certain data </li>
-      </ul>
-
-      <h3 class="govuk-heading-s">Device information </h3>
-      <p class="govuk-body">We will collect data that includes:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>usage data, like IP addresses and technical details of the staff user’s connection</li>
-        <li>equipment, like the phone or laptop used to manage the payment received by the relevant government organisation</li>
       </ul>
 
       <p class="govuk-body">The legal basis for processing this data is to carry out our contract with the relevant government organisations.</p>
@@ -182,7 +168,7 @@ title: Privacy notice
       <p class="govuk-body">If you are a payer, your personal data will be provided to the relevant PSP that’s connected to the government organisation you are paying.</p>
 
       <h3 class="govuk-heading-s">Third party service providers </h3>
-      <p class="govuk-body">We will share your personal data with third parties if they need to know the information so that they can provide us, or the relevant government organisation, with a service. For example, a supplier of IT services like data storage or analytics. </p>
+      <p class="govuk-body">We will share your personal data with third parties if they need to know the information so that they can provide us, or the relevant government organisation, with a service. For example, a supplier of IT services like data storage. </p>
 
       <h3 class="govuk-heading-s">Legal and regulatory entities </h3>
       <p class="govuk-body">We might have to share your personal data with law enforcement agencies or regulatory bodies if we have to comply with any legal obligation or court order. </p>


### PR DESCRIPTION
Description:
- Because we have removed Google Analytics we have to update the information on our product pages to reflect this. Our content writer provided the needed modifications which have been updated