### PR TITLE
PP-5989 Update guidance on payment links so that people don't include PII

### DIFF
--- a/source/govuk-payment-pages.html.erb
+++ b/source/govuk-payment-pages.html.erb
@@ -69,7 +69,9 @@ title: GOV.UK payment pages
 
       <img class="content-section__image" src="/pay-product-page/images/self-service-payments-flow.svg" alt="Example of the payment amount and confirmation pages of the payment link user journey.">
 
-      <p class="govuk-body">Your users will receive a payment reference number and a confirmation email. You can also customise your GOV.UK payment page with a friendly web address.</p>
+      <p class="govuk-body">Your users will receive a payment reference number and a confirmation email.</p>
+      <p class="govuk-body">Use the payment reference to make it easy to identify the payment. You can use numbers or words in your payment reference.</p>
+      <p class="govuk-body">You can also customise your GOV.UK payment page with a friendly web address. Never include personal information in the web address.</p>
 
       <h2 class="govuk-heading-m">When to use a payment link</h2>
       <p class="govuk-body">You don’t need to have a digital service to use payment links.</p>


### PR DESCRIPTION
Update guidance text to explain that Personally Identifiable Information should not be used in the Payment Reference or friendly web address.