### PR TITLE
PP-6191 Improve Copy

### DIFF
--- a/source/govuk-payment-pages.html.erb
+++ b/source/govuk-payment-pages.html.erb
@@ -69,7 +69,9 @@ title: GOV.UK payment pages
 
       <img class="content-section__image" src="/pay-product-page/images/self-service-payments-flow.svg" alt="Example of the payment amount and confirmation pages of the payment link user journey.">
 
-      <p class="govuk-body">Your users will receive a payment reference number and a confirmation email. You can also customise your GOV.UK payment page with a friendly web address.</p>
+      <p class="govuk-body">Your users will receive a payment reference number and a confirmation email.</p>
+      <p class="govuk-body">Use the payment reference to make it easy to identify the payment. You can use numbers or words in your payment reference.</p>
+      <p class="govuk-body">You can also customise your GOV.UK payment page with a friendly web address. Never include personal information in the web address.</p>
 
       <h2 class="govuk-heading-m">When to use a payment link</h2>
       <p class="govuk-body">You don’t need to have a digital service to use payment links.</p>

--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -91,8 +91,8 @@ title: GOV.UK Pay’s Payment Service Provider
 
         <h2 class="govuk-heading-m">Receiving your money from Stripe</h2>
         <p class="govuk-body">Payouts are made in a batch into your bank account 2 working days after the payments have been made. The cut-off time for a day’s payout is midnight UTC.</p>
-        <p class="govuk-body">The payout will display on your bank statement with the description ‘Stripe GOV.UK’.</p>
         <p class="govuk-body">The minimum payout is £1.</p>
+        <p class="govuk-body">The payout from Stripe will appear on your bank statement with a description based on your service’s name.</p>
 
         <h2 class="govuk-heading-m">Paying transaction fees</h2>
         <p class="govuk-body">GOV.UK Pay recoups transaction fees on a ‘net settlement’ basis.</p>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -19,17 +19,22 @@ title: Support
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Support</h1>
-      <p class="govuk-body">GOV.UK Pay is built and supported 24/7 by a full-time team at the Government Digital Service. The Senior Product Manager is Katie Bates.</p>
+      <p class="govuk-body">GOV.UK Pay is built and supported 24/7 by a full-time team at the Government Digital Service.</p>
       <p class="govuk-body">Follow our <a class="govuk-link" href="/getstarted/" data-click-events data-click-category="Content" data-click-action="Internal link clicked">guide to getting started</a> to create an account.</p>
       <p class="govuk-body">GOV.UK Pay’s support is for government services, and does not provide support for individual members of the public paying for services. If you are a member of the public experiencing technical difficulties paying for a specific service, please contact that service’s support directly.</p> 
       <h2 class="govuk-heading-m">Support process</h2>
       <p class="govuk-body">If you have a problem, first check for known issues on the <a class="govuk-link" href="https://payments.statuspage.io/" data-click-events data-click-category="Content" data-click-action="External link clicked">GOV.UK Pay system status page</a>. Subscribe to get alerts on the progress of any listed issue.</p>
 
       <h3 class="govuk-heading-s">During office hours</h3>
-      <p class="govuk-body">Our office hours are 9.30am to 5.30pm, Monday to Friday. You can email us at <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" data-click-events data-click-category="Content" data-click-action="Email link clicked">govuk-pay-support@digital.cabinet-office.gov.uk</a></p>
+      <p class="govuk-body">
+        Our office hours are 9.30am to 5.30pm, Monday to Friday. 
+        You can email us at 
+        <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk" data-click-events data-click-category="Content" data-click-action="Email link clicked">govuk-pay-support@digital.cabinet-office.gov.uk</a>. 
+        We’ll reply within 2 working days. The team are available out of hours in an emergency.
+      </p>
 
-      <h3 class="govuk-heading-s">Out of hours support</h3>
-      <p class="govuk-body">We offer 24 hour online support for critical incidents affecting live production services. We have different response times depending on whether the problem you want to report is an emergency.</p>
+      <h3 class="govuk-heading-s">Out of hours support in an emergency</h3>
+      <p class="govuk-body">We offer 24 hour online support for critical incidents affecting live services. We’ll reply within 30 minutes and give you hourly updates until the problem’s fixed.</p>
       <p class="govuk-body">It’s only an emergency if:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>no one in your team can log in</li>
@@ -37,8 +42,7 @@ title: Support
         <li>you have reasons to believe sensitive data has been leaked</li>
       </ul>
 
-      <p class="govuk-body">We’ll reply within 30 minutes and give you hourly updates until the problem’s fixed.</li></p>
-      <p class="govuk-body">We’ll reply by the next working day for any other problems.</p>
+      <p class="govuk-body">You can find the emergency contact details in your GOV.UK Pay contract or MoU and in the go live email we sent you.</p>
     </div>
   </main>
 </div>


### PR DESCRIPTION
- Update guidance text to explain that Personally Identifiable Information should not be used in the Payment Reference or friendly web address.
- Update text in the 'Receiving your money from Stripe' section
- Update text in the 'Support' section