### PR TITLE
PP-6115 Remove horizontal scroll when cookie banner displayed

### DIFF
--- a/source/pay-product-page/stylesheets/modules/_cookie-banner.scss
+++ b/source/pay-product-page/stylesheets/modules/_cookie-banner.scss
@@ -5,7 +5,6 @@
 }
 
 #global-cookie-message {
-  width: 100%;
   background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
   padding: govuk-spacing(3);
 


### PR DESCRIPTION
Was caused by the width attribute on the banner, remove this and it doesn't cause the horizontal scroll to appear.