### PR TITLE
PP-6274: feature flag for new cookie banner

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -31,10 +31,12 @@ config[:js_dir] = 'pay-product-page/javascripts'
 # Google analytics
 configure :development do
   set :analytics, ""
+  set :new_cookie_banner, false
 end
 
 configure :build do
   set :analytics, "'UA-72121642-9'"
+  set :new_cookie_banner, false
 end
 
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -43,9 +43,15 @@
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-    <div id="global-cookie-message">
-      <p>GOV.UK Pay uses cookies to make the site simpler. <a class="govuk-link" href="https://www.payments.service.gov.uk/cookies/">Find out more about cookies</a></p>
-    </div>
+    <% if config.new_cookie_banner == true %>
+      <!-- TODO insert new cookie banner html -->
+    <% end %>
+    
+    <% if config.new_cookie_banner == false %>
+      <div id="global-cookie-message">
+        <p>GOV.UK Pay uses cookies to make the site simpler. <a class="govuk-link" href="https://www.payments.service.gov.uk/cookies/">Find out more about cookies</a></p>
+      </div>
+    <% end %>
 
     <header class="govuk-header <%= current_page.data.hero && "govuk-header__container--no-border" %>" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">


### PR DESCRIPTION
Add a `new_cookie_banner` config, currently set to false. This can be set to
true manually for local development. When all the stories relating to the new
cookie banner are done - i.e. PP-6274, PP-6271 and PP-6278 -
`new_cookie_banner` can be deleted altogether.