### PR TITLE
PP-6246 Update security page content

### DIFF
--- a/source/api-integration.html.erb
+++ b/source/api-integration.html.erb
@@ -45,7 +45,7 @@ title: Integrating your service with GOV.UK Pay
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/apple-pay-and-google-pay.html.erb
+++ b/source/apple-pay-and-google-pay.html.erb
@@ -45,7 +45,7 @@ title: Using Apple Pay and Google Pay
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/direct-debit.html.erb
+++ b/source/direct-debit.html.erb
@@ -46,7 +46,7 @@ title: Direct Debit on GOV.UK Pay
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/govuk-payment-pages.html.erb
+++ b/source/govuk-payment-pages.html.erb
@@ -46,7 +46,7 @@ title: GOV.UK payment pages
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -46,7 +46,7 @@ title: GOV.UK Pay’s Payment Service Provider
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -45,7 +45,7 @@ title: Roadmap
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/security.html.erb
+++ b/source/security.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Security
+title: Security and compliance
 ---
 <div class="govuk-width-container">
   <div class="govuk-breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
@@ -45,41 +45,78 @@ title: Security
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name"><%= current_page.data.title %></span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>
       </div>
 
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l"><%= current_page.data.title %></h1>
-        <p class="govuk-body">GOV.UK Pay is a secure online payments system.</p>
+        <h1 class="govuk-heading-l">Security and compliance</h1>
+
         <p class="govuk-body">GOV.UK Pay provides a safe and Payment Card Industry (PCI) compliant platform to process card payments.</p>
 
-        <h2 class="govuk-heading-s">PCI compliance</h2>
-        <p class="govuk-body">GOV.UK Pay is certified as a level 1 service provider with the Payment Card Industry Data Security Standard (PCI DSS) version 3.2. The PCI DSS provides guidance to help maintain payment  security.</p>
-        <p class="govuk-body"><a class="govuk-link" href="https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance" data-click-events data-click-category="Content" data-click-action="External link clicked">More information about PCI compliance is available in our technical documentation</a></p>
+        <p class="govuk-body">You can find more information about our security and compliance in the <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/memorandum-of-understanding-for-crown-bodies" data-click-events data-click-category="Content" data-click-action="External link clicked">memorandum of understanding (for crown bodies)</a> and <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/contract-for-non-crown-bodies" data-click-events data-click-category="Content" data-click-action="External link clicked">contract (for non-crown bodies</a>, for example local authorities and the NHS). These are available in the footer when you sign in to your account.</p>
 
-        <h2 class="govuk-heading-s">Government security guidelines</h2>
+        <h2 class="govuk-heading-m">PCI compliance</h2>
+
+        <p class="govuk-body">GOV.UK Pay is certified as a level 1 service provider with the Payment Card Industry Data Security Standard (PCI DSS) version 3.2.1. The PCI DSS provides guidance to help maintain payment security.</p>
+
+        <p class="govuk-body">If you need to see our <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/pci-dss-attestation-of-compliance" data-click-events data-click-category="Content" data-click-action="External link clicked">proof of our compliance</a> (also known as ‘attestation of compliance’), just sign in to your test account and you’ll find a link to it in the footer.</p>
+
+        <p class="govuk-body">If you’d like to <a class="govuk-link" href="https://www.payments.service.gov.uk/take-payments-by-phone-or-post/">take payments by phone or post</a>, you’ll also need to be PCI compliant. Before you can take payments like this, you’ll need to show us proof of your PCI compliance.</p>
+
+        <p class="govuk-body">For a trial period, we’re going to be offering free 1-2-1 support on all your PCI questions. So, <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">get in touch</a> with all your questions.</p>
+
+        <p class="govuk-body"><a class="govuk-link" href="https://docs.payments.service.gov.uk/security/#payment-card-industry-pci-compliance" data-click-events data-click-category="Content" data-click-action="External link clicked">More information about PCI compliance is in our technical documentation.</a></p>
+
+        <h2 class="govuk-heading-m">Government security guidelines</h2>
 
         <p class="govuk-body">GOV.UK Pay supports the <a class="govuk-link" href="https://www.gov.uk/service-manual/technology/using-https" data-click-events data-click-category="Content" data-click-action="External link clicked">government HTTPS security guidelines</a>.</p>
         <p class="govuk-body">HTTPS protects information from being intercepted by malicious third parties as it travels over the internet. Using HTTPS ensures our connections on GOV.UK Pay are secure.</p>
         <p class="govuk-body">GOV.UK Pay also supports all the mandatory requirements for Government ICT systems and services.</p>
 
-        <h2 class="govuk-heading-s">Testing GOV.UK Pay</h2>
+        <h2 class="govuk-heading-m">GOV.UK Pay is independently tested</h2>
+
         <p class="govuk-body">The GOV.UK Pay environment is regularly tested by independent suppliers.</p>
+
         <p class="govuk-body">This includes:</p>
+
         <ul class="govuk-list govuk-list--bullet">
           <li>at least one annual IT Health Check</li>
-          <li>Internal and external vulnerability scanning</li>
+          <li>internal and external vulnerability scanning</li>
         </ul>
-        <p class="govuk-body">GOV.UK Pay is independently assessed for its PCI DSS compliance.</p>
 
-        <h2 class="govuk-heading-s">Cloud Security Principles</h2>
-        <p class="govuk-body">GOV.UK Pay has implemented the <a class="govuk-link" href="https://www.ncsc.gov.uk/collection/cloud-security?curPage=/collection/cloud-security/implementing-the-cloud-security-principles">Cloud Security Principles</a>.</p>
+        <p class="govuk-body">GOV.UK Pay is also independently assessed for its PCI DSS compliance.</p>
 
-        <h2 class="govuk-heading-s">GOV.UK Service Manual</h2>
-        <p class="govuk-body">GDS services follow the standards described in the <a class="govuk-link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a>.</p>
+        <h2 class="govuk-heading-m">Data handling</h2>
+
+        <p class="govuk-body">We only collect the data necessary to run GOV.UK Pay.</p>
+
+        <p class="govuk-body">We won’t retain that data any longer than we need it, and definitely no longer than 7 years, and only share it if it’s necessary to run GOV.UK Pay or if required by law.</p>
+
+        <p class="govuk-body">GOV.UK Pay is the data processor and your service is the data controller. The data protection/data processing agreement is in schedule 4 of the memorandum of understanding and schedule 5 of the contract.</p>
+
+        <h2 class="govuk-heading-m">Liability</h2>
+
+        <p class="govuk-body">Section 13 in the memorandum of understanding and contract sets out the liability between GOV.UK Pay and your service.</p>
+
+        <h2 class="govuk-heading-m">Fraud prevention</h2>
+
+        <p class="govuk-body">While anti-fraud measures are generally set by your payment service provider, we have <a class="govuk-link" href="https://docs.payments.service.gov.uk/security/#preventing-fraudulent-payments" data-click-events data-click-category="Content" data-click-action="External link clicked">designed some features to help</a>.</p>
+
+        <p class="govuk-body">For instance, you can block users from using prepaid cards to make payments. Or, Worldpay users can set their account to refuse a transaction if IP address isn’t provided. This is particularly useful if your service has a higher risk profile.</p>
+
+        <h2 class="govuk-heading-m">Cloud Security Principles</h2>
+
+        <p class="govuk-body">GOV.UK Pay has implemented the <a class="govuk-link" href="https://www.ncsc.gov.uk/collection/cloud-security?curPage=/collection/cloud-security/implementing-the-cloud-security-principles" data-click-events data-click-category="Content" data-click-action="External link clicked">Cloud Security Principles</a>.</p>
+
+        <h2 class="govuk-heading-m">Accessibility</h2>
+
+        <p class="govuk-body">GOV.UK Pay is fully compliant with the <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/" data-click-events data-click-category="Content" data-click-action="External link clicked">Web Content Accessibility Guidelines version 2.1</a> AA. More information is in our <a class="govuk-link" href="https://www.payments.service.gov.uk/accessibility-statement/">accessibility statement</a>.</p>
+
+        <h2 class="govuk-heading-m">GOV.UK Service Manual</h2>
+        <p class="govuk-body">GDS services follow the standards described in the <a class="govuk-link" href="https://www.gov.uk/service-manual" data-click-events data-click-category="Content" data-click-action="External link clicked">GOV.UK Service Manual</a>.</p>
 
         <p class="govuk-body">The standards describe the best way to build and run a service and include advice about:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -88,6 +125,10 @@ title: Security
           <li>design</li>
           <li>technology</li>
         </ul>
+
+        <h2 class="govuk-heading-m">Further information</h2>
+
+        <p class="govuk-body">Further detail about security and compliance is available in the memorandum of understanding (for crown bodies) and contract (for non-crown bodies) and in our <a class="govuk-link" href="https://docs.payments.service.gov.uk/security/#security" data-click-events data-click-category="Content" data-click-action="External link clicked">technical documentation</a>.</p>
     </div>
   </main>
 </div>

--- a/source/take-payments-by-phone-or-post.html.erb
+++ b/source/take-payments-by-phone-or-post.html.erb
@@ -45,7 +45,7 @@ title: Take payments by phone or post
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>

--- a/source/using-govuk-pay.html.erb
+++ b/source/using-govuk-pay.html.erb
@@ -46,7 +46,7 @@ title: Using GOV.UK Pay
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+              <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
             </li>
           </ol>
         </nav>


### PR DESCRIPTION
- use new content
- make subheadings medium size to be consistent with other pages
- rename page to "Security and compliance" in sidebar