### PR TITLE
PP-6271 Allow user to update Cookie Analytic preferences via the /coo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "jest": {
     "testEnvironment": "node"
   },
+  "scripts": {
+    "test": "jest"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alphagov/product-page-example.git"

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -18,6 +18,11 @@ title: Cookies
   <main id="main-content" class="govuk-main-wrapper" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+
+      <% if config.new_cookie_banner == true %>      
+        <%= partial 'partials/cookie-settings-confirmation.erb' %>
+      <% end %>
+
       <h1 class="govuk-heading-l" id="heading-1">Cookies</h1>
       <p class="govuk-body-l">
         GOV.UK&nbsp;Pay puts small files (known as ‘cookies’) on to your computer.
@@ -105,6 +110,76 @@ title: Cookies
           </tr>
         </tbody>
       </table>
+
+      <% if config.new_cookie_banner == true %>
+        <h2 class="govuk-heading-m">Analytics cookies (optional)</h2>
+        <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Pay. This information helps us to improve our service.</p>
+        <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
+        <p class="govuk-body">Google Analytics stores anonymised information about:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>how you got to GOV.UK Pay</li>
+          <li>the pages you visit on Pay and how long you spend on them</li>
+          <li>any errors you see while using Pay</li>
+        </ul>
+        <table class="govuk-table">
+          <caption class="govuk-visually-hidden">Google Analytics cookies</caption>
+          <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+              <th class="govuk-table__header govuk-!-width-one-third" scope="col">Name</th>
+              <th class="govuk-table__header" scope="col">Purpose</th>
+              <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__cell govuk-table__head" scope="row">_ga</th>
+              <td class="govuk-table__cell">Checks if you’ve visited Pay before. This helps us count how many people visit our site.</td>
+              <td class="govuk-table__cell">2 years</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th class="govuk-table__cell govuk-table__head" scope="row">_gid</th>
+              <td class="govuk-table__cell">Checks if you’ve visited Pay before. This helps us count how many people visit our site.</td>
+              <td class="govuk-table__cell">24 years</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="cookie-settings__no-js">
+          <h2 class="govuk-heading-s govuk-!-margin-top-6">Do you want to accept analytics cookies?</h2>
+          <p class="govuk-body">We use Javascript to set our analytics cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>reloading the page</li>
+            <li>turning on Javascript in your browser</li>
+          </ul>
+        </div>
+
+        <div class="cookie-settings__form-wrapper">
+          <form data-module="cookie-settings-form" id="cookie-settings-form">
+            <div class="govuk-form-group govuk-!-margin-top-6">
+              <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                  Do you want to accept analytics cookies?
+                </legend>
+                <div class="govuk-radios govuk-radios--inline">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies-analytics" type="radio" value="on">
+                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                      Yes
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies-analytics" type="radio" value="off">
+                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                      No
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            <button class="govuk-button" type="submit">Save cookie settings</button>
+          </form>
+        </div>    
+      <% end %>
     </div>
   </main>
 </div>

--- a/source/partials/_cookie-settings-confirmation.erb
+++ b/source/partials/_cookie-settings-confirmation.erb
@@ -1,0 +1,32 @@
+<div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--error" id="pay-cookie-settings-error" tabindex="0" >
+    <h2>
+        There was a problem saving your settings
+    </h2>
+    
+    <div class="pay-cookie-settings-alert__body">
+        Please select 'Yes' or 'No'.
+    </div>    
+</div>
+
+<div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--warning" id="pay-cookie-settings-warning" tabindex="0">
+    <h2>
+        Your cookie settings have not yet been saved
+    </h2>
+    
+        <div class="pay-cookie-settings-alert__body">
+            Pay sets cookies when you visit our website. You can choose to change these settings to your own preferences. You need to save this page with your new choices.
+        </div>
+    
+</div>
+
+<div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--success" id="pay-cookie-settings-success" tabindex="0" >
+    <h2>
+        Your cookie settings were saved
+    </h2>
+    
+        <div class="pay-cookie-settings-alert__body">
+            <p class="govuk-body">You can change your preferences at any time on this page.</p><p class="govuk-body"><a href="/cookies" class="govuk-link pay-cookie-settings__prev-page">Go back to the page you were looking at.</a></p>
+        </div>    
+</div>
+
+

--- a/source/pay-product-page/javascripts/application.js
+++ b/source/pay-product-page/javascripts/application.js
@@ -2,9 +2,11 @@
 //= require gaap-analytics.min.js
 //= require cookies.js
 //= require ./cookie-banner/cookie-banner.js
+//= require ./cookie-settings/cookie-settings.js
 
 document.addEventListener("DOMContentLoaded", function(event) {
   GOVUKFrontend.initAll()
   GAAP.analytics.eventTracking.init()
   window.GovUkPay.CookieBanner.checkForBannerAndInit();
+  window.GovUkPay.CookieSettings.checkForFormAndInit();
 });

--- a/source/pay-product-page/javascripts/cookie-banner/cookie-banner.test.js
+++ b/source/pay-product-page/javascripts/cookie-banner/cookie-banner.test.js
@@ -106,18 +106,18 @@ describe("Cookie Banner", () => {
     });
   });
 
-  describe('Confirmation mesage', () => {
+  describe("Confirmation mesage", () => {
     it(`hide button works`, () => {
       window.GovUkPay.CookieBanner.checkForBannerAndInit();
       document.querySelector("button[data-accept-cookies=true]").click();
-  
+
       const confirmBanner = document.querySelector(
         ".pay-cookie-banner__confirmation"
       );
       expect(confirmBanner.style.display).toEqual("block");
 
-      confirmBanner.querySelector('.pay-cookie-banner__hide-button').click();
-      expect(confirmBanner.style.display).toEqual('none');
+      confirmBanner.querySelector(".pay-cookie-banner__hide-button").click();
+      expect(confirmBanner.style.display).toEqual("none");
     });
-  })
+  });
 });

--- a/source/pay-product-page/javascripts/cookie-settings/cookie-settings.js
+++ b/source/pay-product-page/javascripts/cookie-settings/cookie-settings.js
@@ -1,0 +1,149 @@
+//= require '../helpers/cookie/cookie-functions.js'
+
+window.GovUkPay = window.GovUkPay || {};
+window.GovUkPay.CookieSettings = (function() {
+    $module = {}
+
+    checkForFormAndInit = function() {
+        var $cookieSettingsForm = document.querySelector(
+            '#cookie-settings-form'
+        );
+
+        if ($cookieSettingsForm) {
+            setModule($cookieSettingsForm);
+            init();
+        }
+    };
+
+    var setModule = function($form) {
+        $module = $form
+    }
+
+    var init = function() {
+        $module.addEventListener("submit", submitSettingsForm);
+
+        // Ensure there aren't two forms for setting cookie preferences on the same page
+        hideElement('.pay-cookie-banner');
+
+        setInitialFormValues();
+    };
+
+    var setInitialFormValues = function() {
+        var currentConsentCookie = window.GovUkPay.Cookie.getConsentCookie();
+
+        if (!currentConsentCookie) {
+            // Don't populate the form
+            return;
+        }
+
+        hideElement('#pay-cookie-settings-warning');
+
+        // Populate the form with the existing choice
+        var radioButton;
+        if (currentConsentCookie.analytics) {
+            radioButton = $module.querySelector(
+                "input[name=cookies-analytics][value=on]"
+            );
+        } else {
+            radioButton = $module.querySelector(
+                "input[name=cookies-analytics][value=off]"
+            );
+        }
+        radioButton.checked = true;
+    };
+
+    var submitSettingsForm = function(event) {
+        event.preventDefault();
+
+        var formInputs = event.target.querySelectorAll(
+            "input[name=cookies-analytics]"
+        );
+        var options = {};
+
+        // Retrieve the selected value from the form inputs
+        for (var i = 0; i < formInputs.length; i++) {
+            var input = formInputs[i];
+            if (input.checked) {
+                var value = input.value === "on";
+
+                options.analytics = value;
+                break;
+            }
+        }
+        // the cookie choice must be set when form is submitted
+        if (options.analytics === undefined) {
+            showErrorMessage();
+            return false;
+        }
+
+        // Set the analytics cookie preferences
+        // If 'Off' option not checked, this function will also delete any existing Google Analytics cookies
+        window.GovUkPay.Cookie.setConsentCookie(options);
+
+        // If 'On' option checked and analytics not yet present,
+        // initialise Analytics (this includes firing the initial pageview)
+        if (options.analytics) {
+            window.GovUkPay.InitAnalytics.InitialiseAnalytics();
+        }
+
+        hideElement('#pay-cookie-settings-warning');
+        hideElement("#pay-cookie-settings-error");
+        showConfirmationMessage();
+
+        return false;
+    };
+
+    var showConfirmationMessage = function() {
+        var confirmationMessage = document.querySelector(
+            "#pay-cookie-settings-success"
+        );
+        var previousPageLink = document.querySelector(
+            ".pay-cookie-settings__prev-page"
+        );
+        var referrer = getReferrerLink();
+
+        document.body.scrollTop = document.documentElement.scrollTop = 0;
+
+        if (referrer && referrer !== document.location.pathname) {
+            previousPageLink.href = referrer;
+            previousPageLink.style.display = "block";
+        } else {
+            previousPageLink.style.display = "none";
+        }
+
+        confirmationMessage.style.display = "block";
+    };
+
+    var showErrorMessage = function() {
+        var errorMessage = document.querySelector("#pay-cookie-settings-error");
+        if (errorMessage !== null) {
+            errorMessage.style.display = "block";
+            document.body.scrollTop = document.documentElement.scrollTop = 0;
+        }
+    };
+
+    var hideElement  = function(cssSelector) {
+        var errorMessage = document.querySelector(cssSelector);
+        if (errorMessage !== null) {
+            errorMessage.style.display = "none";
+        } 
+    }
+
+
+    var getReferrerLink = function() {
+        return document.referrer ? new URL(document.referrer).pathname : false;
+    };
+
+    return {
+        setModule: setModule,
+        submitSettingsForm: submitSettingsForm,
+        checkForFormAndInit: checkForFormAndInit,
+        init: init,
+        setInitialFormValues: setInitialFormValues,
+        submitSettingsForm: submitSettingsForm,
+        showConfirmationMessage: showConfirmationMessage,
+        showErrorMessage: showErrorMessage,
+        hideElement: hideElement,
+        getReferrerLink: getReferrerLink
+    }
+})();

--- a/source/pay-product-page/javascripts/cookie-settings/cookie-settings.test.js
+++ b/source/pay-product-page/javascripts/cookie-settings/cookie-settings.test.js
@@ -1,0 +1,297 @@
+/**
+ * @jest-environment jsdom
+ */
+const JsCookie = require("js-cookie");
+const testCookiePageTemplate = require("./test-cookie-page-template");
+
+const formInputsForMock = jest.fn((param) => {
+  // Return the form input objects
+  let inputs = [];
+  if (param === "on") {
+    inputs = [{ checked: true, value: "on" }, { value: "off" }];
+  } else if (param === "off") {
+    inputs = [{ checked: true, value: "off" }, { value: "on" }];
+  } else if (param === "neither") {
+    inputs = [{ value: "on" }, { value: "off" }];
+  }
+  return inputs;
+});
+
+const mockSubmitEvent = jest.fn((param) => {
+  const submitEvent = jest.fn();
+  submitEvent.target = jest.fn();
+  submitEvent.preventDefault = jest.fn();
+  submitEvent.target.querySelectorAll = jest.fn();
+  submitEvent.target.querySelectorAll.mockImplementation(() => {
+    return formInputsForMock(param);
+  });
+  return submitEvent;
+});
+
+describe("Cookie settings", () => {
+  beforeEach(() => {
+    window.GovUkPay = window.GovUkPay || {};
+    window.GovUkPay.InitAnalytics = {};
+    window.GovUkPay.InitAnalytics.InitialiseAnalytics = jest.fn();
+
+    require("../helpers/cookie/cookie-functions");
+    require("./cookie-settings");
+
+    JsCookie.remove("govuk_pay_cookie_policy");
+
+    document.body.innerHTML = testCookiePageTemplate;
+
+    document.querySelector(".pay-cookie-settings-alert--error").style.display =
+      "none";
+    document.querySelector(
+      ".pay-cookie-settings-alert--success"
+    ).style.display = "none";
+  });
+
+  describe("initialising the component", () => {
+    it("hides the cookie banner if present", () => {
+      window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+      expect(
+        document.querySelector("#pay-cookie-banner").style.display
+      ).toEqual("none");
+    });
+
+    describe("without existing analytics", () => {
+      it("does not hide the warning message", () => {
+        window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--warning").style
+            .display
+        ).not.toEqual("none");
+      });
+    });
+
+    describe("with existing analytics", () => {
+      it("hides the warning message", () => {
+        JsCookie.set("govuk_pay_cookie_policy", `{"analytics": true}`);
+        window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--warning").style
+            .display
+        ).toEqual("none");
+      });
+    });
+
+    describe("initialising the Cookie Settings radio buttons", () => {
+      it("when no cookie present - no radio buttons are checked", () => {
+        window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=on]")
+            .checked
+        ).toEqual(false);
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=off]")
+            .checked
+        ).toEqual(false);
+      });
+
+      it("cookie with analytics=true - ON radio button is checked", () => {
+        JsCookie.set("govuk_pay_cookie_policy", `{"analytics": true}`);
+        window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=on]")
+            .checked
+        ).toEqual(true);
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=off]")
+            .checked
+        ).toEqual(false);
+      });
+
+      it("cookie with analytics=false - OFF radio button is checked", () => {
+        JsCookie.set("govuk_pay_cookie_policy", `{"analytics": false}`);
+        window.GovUkPay.CookieSettings.checkForFormAndInit();
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=on]")
+            .checked
+        ).toEqual(false);
+
+        expect(
+          document.querySelector("input[name=cookies-analytics][value=off]")
+            .checked
+        ).toEqual(true);
+      });
+    });
+  });
+
+  describe("Submitting the form", () => {
+    describe("with No selected", () => {
+      let submitEvent;
+      beforeEach(() => {
+        submitEvent = mockSubmitEvent("off");
+      });
+
+      it("sets consent cookie", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(submitEvent.preventDefault).toHaveBeenCalled();
+        const consentCookie = JsCookie.get("govuk_pay_cookie_policy");
+        const consentCookieJson = JSON.parse(consentCookie);
+        expect(consentCookieJson).toEqual({
+          analytics: false,
+        });
+      });
+
+      it("does not initialise Analytics", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+        expect(
+          window.GovUkPay.InitAnalytics.InitialiseAnalytics
+        ).not.toHaveBeenCalled();
+      });
+
+      it("shows confirmation message and hides other messages", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--warning").style
+            .display
+        ).toEqual("none");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--error").style
+            .display
+        ).toEqual("none");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--success").style
+            .display
+        ).toEqual("block");
+      });
+    });
+
+    describe("with Yes selected", () => {
+      let submitEvent;
+      beforeEach(() => {
+        submitEvent = mockSubmitEvent("on");
+      });
+
+      it("sets consent cookie", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(submitEvent.preventDefault).toHaveBeenCalled();
+        const consentCookie = JsCookie.get("govuk_pay_cookie_policy");
+        const consentCookieJson = JSON.parse(consentCookie);
+        expect(consentCookieJson).toEqual({
+          analytics: true,
+        });
+      });
+
+      it("initialises Analytics", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+        expect(
+          window.GovUkPay.InitAnalytics.InitialiseAnalytics
+        ).toHaveBeenCalled();
+      });
+
+      it("shows confirmation message and hides other messages", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--warning").style
+            .display
+        ).toEqual("none");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--error").style
+            .display
+        ).toEqual("none");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--success").style
+            .display
+        ).toEqual("block");
+      });
+    });
+
+    describe("with nothing selected", () => {
+      let submitEvent;
+      beforeEach(() => {
+        submitEvent = mockSubmitEvent("neither");
+      });
+
+      it("does not set consent cookie", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(submitEvent.preventDefault).toHaveBeenCalled();
+        const consentCookie = JsCookie.get("govuk_pay_cookie_policy");
+        expect(consentCookie).toBeUndefined();
+      });
+
+      it("does not initialise Analytics", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+        expect(
+          window.GovUkPay.InitAnalytics.InitialiseAnalytics
+        ).not.toHaveBeenCalled();
+      });
+
+      it("shows error message", () => {
+        window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--warning").style
+            .display
+        ).not.toEqual("none");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--error").style
+            .display
+        ).toEqual("block");
+        expect(
+          document.querySelector(".pay-cookie-settings-alert--success").style
+            .display
+        ).not.toEqual("block");
+      });
+    });
+
+    describe("after changing cookie settings - sets the back link in the success alert", () => {
+        let submitEvent;
+        beforeEach(() => {
+            submitEvent = mockSubmitEvent("on");
+        });
+  
+        it("when there is no referrer, it does NOT show a back link", () => {
+            Object.defineProperty(window.document, 'referrer', { value: null, configurable: true })
+          window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+  
+          expect(
+            document.querySelector(".pay-cookie-settings__prev-page").style
+              .display
+          ).toEqual("none");
+        });
+
+        it("when there is a referrer, it does show a back link", () => {
+            Object.defineProperty(window.document, 'referrer', { value: "http://localhost/page1", configurable: true })  
+          window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+  
+          expect(
+            document.querySelector(".pay-cookie-settings__prev-page").style
+              .display
+          ).toEqual("block");
+
+          expect(
+            document.querySelector(".pay-cookie-settings__prev-page").href
+          ).toEqual("http://localhost/page1");
+        });
+
+        it("when the referrer is the same page, do not show back link", () => {
+            Object.defineProperty(window.document, 'referrer', { value: "http://localhost/", configurable: true
+         })  
+          window.GovUkPay.CookieSettings.submitSettingsForm(submitEvent);
+  
+          expect(
+            document.querySelector(".pay-cookie-settings__prev-page").style
+              .display
+          ).toEqual("none");
+
+        });
+      });
+  });
+});

--- a/source/pay-product-page/javascripts/cookie-settings/test-cookie-page-template.js
+++ b/source/pay-product-page/javascripts/cookie-settings/test-cookie-page-template.js
@@ -1,0 +1,41 @@
+module.exports = 
+`
+    <div id="pay-cookie-banner" class="pay-cookie-banner">
+        Cookie Banner
+    </div>
+
+    <div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--error" id="pay-cookie-settings-error" tabindex="0" >
+        <h2>
+            There was a problem saving your settings
+        </h2>
+        <div class="pay-cookie-settings-alert__body">
+            Please select 'Yes' or 'No'.
+        </div>    
+    </div>
+
+    <div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--warning" id="pay-cookie-settings-warning" tabindex="0">
+        <h2>
+            Your cookie settings have not yet been saved
+        </h2>
+
+        <div class="pay-cookie-settings-alert__body">
+            Pay sets cookies when you visit our website. You can choose to change these settings to your own preferences. You need to save this page with your new choices.
+        </div>
+    </div>
+
+    <div data-module="pay-cookie-settings-alert" class="pay-cookie-settings-alert pay-cookie-settings-alert--success" id="pay-cookie-settings-success" tabindex="0" >
+        <h2>
+            Your cookie settings were saved
+        </h2>
+    
+        <div class="pay-cookie-settings-alert__body">
+            <p class="govuk-body">You can change your preferences at any time on this page.</p><p class="govuk-body"><a href="/cookies" class="govuk-link pay-cookie-settings__prev-page">Go back to the page you were looking at.</a></p>
+        </div>    
+    </div>
+
+    <form id='cookie-settings-form'>
+        <input type="radio" name="cookies-analytics" value=on />'
+        <input type="radio" name="cookies-analytics" value=off />'
+        <button type="submit">Save cookie settings</button>
+    </form>
+`

--- a/source/pay-product-page/stylesheets/modules/_cookie-settings.scss
+++ b/source/pay-product-page/stylesheets/modules/_cookie-settings.scss
@@ -1,0 +1,44 @@
+// .js-enabled {
+.cookie-settings__no-js{
+    .js-enabled & {
+        display: none;
+    }
+}
+
+.pay-cookie-settings-alert {
+    @include govuk-font(19);
+    display: block;
+    padding: govuk-spacing(3);
+    margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
+    text-align: left;
+    position: relative;
+    clear: both;
+    border-style: solid;
+    border-width: 5px;
+    display: none;
+
+    .js-enabled & {
+        &--warning {
+            display: block;
+            border-color: govuk-colour("blue");
+        }
+        
+        &--success {
+            display: none;
+            border-color: govuk-colour("green")
+        }
+        
+        &--error {
+            display: none;
+            border-color: govuk-colour("red")
+        }
+    }
+}
+
+.cookie-settings__form-wrapper{
+    display: none;
+
+    .js-enabled & {
+        display: block;
+    } 
+}

--- a/source/pay-product-page/stylesheets/screen.css.scss
+++ b/source/pay-product-page/stylesheets/screen.css.scss
@@ -8,6 +8,7 @@ $govuk-assets-path: "/assets/govuk/assets/";
 @import "modules/breadcrumbs";
 @import "modules/content-section";
 @import "modules/cookie-banner";
+@import "modules/cookie-settings";
 @import "modules/header";
 @import "modules/hero";
 @import "modules/hero-alternative-action";


### PR DESCRIPTION
…kie page

- Added a form at the bottom of the /Cookie page
  - Allows user to consent or decline the use of Analytic cookies.
- When they go the page, if they have not set any cookie prefs previously, then it shows
 warning saying they can update their prefs.
- If they click YES or NO, a cookie is saved which remembers their preference.
- All functionality in cookie-settings.js file.
- Requires the work done for the Cookie Banner.
- Added SCSS styling.
- Added Unit Tests