### PR TITLE
PP-6271 Fix cookie banner event handlers

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -28,6 +28,8 @@ config[:images_dir] = 'pay-product-page/images'
 config[:fonts_dir] = 'pay-product-page/fonts'
 config[:js_dir] = 'pay-product-page/javascripts'
 
+ignore '**/javascripts/*test*.js'
+
 # Google analytics
 configure :development do
   set :analytics, ""
@@ -36,7 +38,7 @@ end
 
 configure :build do
   set :analytics, "'UA-72121642-9'"
-  set :new_cookie_banner, false
+  set :new_cookie_banner, true
 end
 
 

--- a/config.rb
+++ b/config.rb
@@ -28,8 +28,6 @@ config[:images_dir] = 'pay-product-page/images'
 config[:fonts_dir] = 'pay-product-page/fonts'
 config[:js_dir] = 'pay-product-page/javascripts'
 
-ignore '**/*test*.js'
-
 # Google analytics
 configure :development do
   set :analytics, ""
@@ -38,7 +36,7 @@ end
 
 configure :build do
   set :analytics, "'UA-72121642-9'"
-  set :new_cookie_banner, true
+  set :new_cookie_banner, false
 end
 
 

--- a/source/pay-product-page/javascripts/cookie-banner/cookie-banner.js
+++ b/source/pay-product-page/javascripts/cookie-banner/cookie-banner.js
@@ -41,18 +41,18 @@ window.GovUkPay.CookieBanner = (function () {
       "button[data-accept-cookies=true]"
     );
     if (this.$acceptCookiesLink) {
-      this.$acceptCookiesLink.addEventListener("click", () =>
-        setCookieConsent(true)
-      );
+      this.$acceptCookiesLink.addEventListener("click", function () {
+        setCookieConsent(true);
+      })
     }
 
     this.$rejectCookiesLink = $module.cookieBanner.querySelector(
       "button[data-accept-cookies=false]"
     );
     if (this.$rejectCookiesLink) {
-      this.$rejectCookiesLink.addEventListener("click", () =>
-        setCookieConsent(false)
-      );
+      this.$rejectCookiesLink.addEventListener("click", function () {
+        setCookieConsent(false);
+      })
     }
 
     this.showCookieMessage();

--- a/source/pay-product-page/javascripts/cookie-banner/cookie-banner.js
+++ b/source/pay-product-page/javascripts/cookie-banner/cookie-banner.js
@@ -1,116 +1,119 @@
 //= require ../helpers/cookie/cookie-functions.js
 //= require ../analytics/init.js
 
-window.GovUkPay = window.GovUkPay || {}
+window.GovUkPay = window.GovUkPay || {};
 
 window.GovUkPay.CookieBanner = (function () {
-  var $module = {}
-  var COOKIE_NAME = 'govuk_pay_cookie_policy'
+  $module = {};
+  COOKIE_NAME = "govuk_pay_cookie_policy";
 
-  var setModule = function ($module) {
-    this.$module = $module
-  }
+  setModule = function ($module) {
+    $module = $module;
+  };
 
-  var checkForBannerAndInit = function () {
+  checkForBannerAndInit = function () {
     var $cookieBanner = document.querySelector(
       '[data-module="pay-cookie-banner"]'
-    )
+    );
 
     if ($cookieBanner) {
-      setModule($cookieBanner)
-      init($module)
+      setModule($cookieBanner);
+      init($module);
     }
-  }
+  };
 
-  var init = function ($module) {
-    $module.cookieBanner = document.querySelector('.pay-cookie-banner')
+  init = function ($module) {
+    $module.cookieBanner = document.querySelector(".pay-cookie-banner");
     $module.cookieBannerConfirmationMessage = document.querySelector(
-      '.pay-cookie-banner__confirmation'
-    )
+      ".pay-cookie-banner__confirmation"
+    );
 
-    setupCookieMessage()
-  }
+    setupCookieMessage();
+  };
 
-  var setupCookieMessage = function () {
-    this.$hideLink = $module.cookieBannerConfirmationMessage.querySelector('button[data-hide-cookie-banner]')
+  setupCookieMessage = function () {
+    this.$hideLink = $module.cookieBannerConfirmationMessage.querySelector("button[data-hide-cookie-banner]");
     if (this.$hideLink) {
-      this.$hideLink.addEventListener('click', hideCookieMessage)
+      this.$hideLink.addEventListener("click", hideCookieMessage);
     }
 
     this.$acceptCookiesLink = $module.cookieBanner.querySelector(
-      'button[data-accept-cookies=true]'
-    )
-
+      "button[data-accept-cookies=true]"
+    );
     if (this.$acceptCookiesLink) {
-      this.$acceptCookiesLink.addEventListener('click', setCookieConsent(true))
+      this.$acceptCookiesLink.addEventListener("click", () =>
+        setCookieConsent(true)
+      );
     }
 
     this.$rejectCookiesLink = $module.cookieBanner.querySelector(
-      'button[data-accept-cookies=false]'
-    )
+      "button[data-accept-cookies=false]"
+    );
     if (this.$rejectCookiesLink) {
-      this.$rejectCookiesLink.addEventListener('click', setCookieConsent(false))
+      this.$rejectCookiesLink.addEventListener("click", () =>
+        setCookieConsent(false)
+      );
     }
 
-    this.showCookieMessage()
-  }
+    this.showCookieMessage();
+  };
 
-  var showCookieMessage = function () {
+  showCookieMessage = function () {
     // Show the cookie banner if policy cookie not set
     var hasCookiesPolicy = window.GovUkPay.Cookie.getCookie(COOKIE_NAME)
 
     if ($module.cookieBanner) {
       if (!hasCookiesPolicy) {
-        $module.cookieBanner.style.display = 'block'
+        $module.cookieBanner.style.display = "block"
       } else {
-        const consentCookieObj = window.GovUkPay.Cookie.getConsentCookie()
+        const consentCookieObj =window.GovUkPay.Cookie.getConsentCookie()
         if (consentCookieObj && consentCookieObj.analytics === true) {
-          window.GovUkPay.InitAnalytics.InitialiseAnalytics()
+          window.GovUkPay.InitAnalytics.InitialiseAnalytics();
         }
-        $module.cookieBanner.style.display = 'none'
+        $module.cookieBanner.style.display = "none"
       }
     }
   }
 
-  var hideCookieMessage = function (event) {
+  hideCookieMessage = function (event) {
     if ($module.cookieBannerConfirmationMessage) {
-      $module.cookieBannerConfirmationMessage.style.display = 'none'
+      $module.cookieBannerConfirmationMessage.style.display = "none";
     }
 
     if (event.target) {
-      event.preventDefault()
+      event.preventDefault();
     }
-  }
+  };
 
-  var setCookieConsent = function (analyticsConsent) {
-    window.GovUkPay.Cookie.setConsentCookie({ analytics: analyticsConsent })
+  setCookieConsent = function (analyticsConsent) {
+    window.GovUkPay.Cookie.setConsentCookie({ analytics: analyticsConsent });
 
-    showConfirmationMessage(analyticsConsent)
-    $module.cookieBannerConfirmationMessage.focus()
+    showConfirmationMessage(analyticsConsent);
+    $module.cookieBannerConfirmationMessage.focus();
     if (analyticsConsent) {
-      window.GovUkPay.InitAnalytics.InitialiseAnalytics()
+      window.GovUkPay.InitAnalytics.InitialiseAnalytics();
     }
-  }
+  };
 
-  var showConfirmationMessage = function (analyticsConsent) {
+  showConfirmationMessage = function (analyticsConsent) {
     var messagePrefix = analyticsConsent
-      ? 'You’ve accepted analytics cookies.'
-      : 'You told us not to use analytics cookies.'
+      ? "You’ve accepted analytics cookies."
+      : "You told us not to use analytics cookies.";
 
     var $cookieBannerMainContent = document.querySelector(
-      '.pay-cookie-banner__wrapper'
-    )
+      ".pay-cookie-banner__wrapper"
+    );
     var $cookieBannerConfirmationMessage = document.querySelector(
-      '.pay-cookie-banner__confirmation-message'
-    )
+      ".pay-cookie-banner__confirmation-message"
+    );
 
     $cookieBannerConfirmationMessage.insertAdjacentText(
-      'afterbegin',
+      "afterbegin",
       messagePrefix
-    )
-    $cookieBannerMainContent.style.display = 'none'
-    $module.cookieBannerConfirmationMessage.style.display = 'block'
-  }
+    );
+    $cookieBannerMainContent.style.display = "none";
+    $module.cookieBannerConfirmationMessage.style.display = "block";
+  };
 
   return {
     setModule: setModule,
@@ -120,6 +123,6 @@ window.GovUkPay.CookieBanner = (function () {
     showCookieMessage: showCookieMessage,
     hideCookieMessage: hideCookieMessage,
     setCookieConsent: setCookieConsent,
-    showConfirmationMessage: showConfirmationMessage
-  }
-})()
+    showConfirmationMessage: showConfirmationMessage,
+  };
+})();

--- a/source/pay-product-page/stylesheets/modules/_hero-button.scss
+++ b/source/pay-product-page/stylesheets/modules/_hero-button.scss
@@ -21,7 +21,6 @@ a.hero-button {
   @include bold-24;
   @include box-shadow(0 2px 0 darken($govuk-blue, 10%));
 
-  background-image: file-url('/pay-product-page/images/hero-button/arrow.png');
   background-size: 20px;
   background-repeat: no-repeat;
   background-position: 95% 50%;

--- a/source/pay-product-page/stylesheets/modules/_hero.scss
+++ b/source/pay-product-page/stylesheets/modules/_hero.scss
@@ -139,7 +139,6 @@
   .button--start_white:visited {
     background-color: govuk-colour("white");
     color: $govuk-brand-colour;
-    background-image: url("/public/images/arrow.png");
     background-size: 20px;
     background-position: 96% 50%;
     box-shadow: 0 2px 0 #004172;


### PR DESCRIPTION
## WHAT

- Reverts 64f80b66164ec1c883c8a1472a65fb1491dd58a8 as it broken cookie banner
- Change ES6 style invocation to event handler functions
- Ignore tests from middlemand build

with @sfount, @sandorarpa, @iqbalgds