### PR TITLE
BAU — Correct Stripe payout cut-off time from midnight to 9:00pm

### DIFF
--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -93,7 +93,7 @@ title: GOV.UK Pay’s Payment Service Provider
         </ul>
 
         <h2 class="govuk-heading-m">Receiving your money from Stripe</h2>
-        <p class="govuk-body">Payouts are made in a batch into your bank account 2 working days after the payments have been made. The cut-off time for a day’s payout is midnight UTC.</p>
+        <p class="govuk-body">Payouts are made in a batch into your bank account 2 working days after the payments have been made. The cut-off time for a day’s payout is 9:00pm UTC.</p>
         <p class="govuk-body">The minimum payout is £1.</p>
         <p class="govuk-body">The payout from Stripe will appear on your bank statement with a description based on your service’s name.</p>
         <p class="govuk-body">If you want to change this description, just contact the GOV.UK Pay team.</p>


### PR DESCRIPTION
Stripe support confirmed that the cut-off time for a payment to be included in the payout two days later is 9:00pm UTC, not midnight.