### PR TITLE
PP-7089 Fix product page navigation banner links

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -80,7 +80,6 @@
             <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
             <%
               {
-                'About' => '/',
                 'Get started' => '/getstarted/',
                 'Documentation' => 'https://docs.payments.service.gov.uk',
                 'Support' => '/support/',

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -46,7 +46,7 @@
     <% if config.new_cookie_banner == true %>
       <%= partial 'partials/cookie-banner.erb' %>
     <% end %>
-    
+
     <% if config.new_cookie_banner == false %>
       <div id="global-cookie-message">
         <p>GOV.UK Pay uses cookies to make the site simpler. <a class="govuk-link" href="https://www.payments.service.gov.uk/cookies/">Find out more about cookies</a></p>
@@ -88,7 +88,7 @@
               }.each do |title, url|
             %>
               <li class="govuk-header__navigation-item<% if url == current_page.url %> govuk-header__navigation-item--active" aria-current="page<% end %>">
-                <a class="govuk-header__link" href="<%= url == current_page.url ? "#main" : url %>">
+                <a class="govuk-header__link" href="<%= url %>">
                   <%= title %>
                 </a>
               </li>


### PR DESCRIPTION
Remove `#main` id from the href for the top banner navigation links when we are already on the page as it points to a non-existent element.

Remove redundant About link. 'About' doesn't indicate that it goes back to the landing page. To get to the landing page, it is possible to click on the logo.