### PR TITLE
Remove the accessibility failures we've fixed

### DIFF
--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -46,14 +46,8 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
       <p class="govuk-body">For users in government service teams:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>field labels may not be announced to screen readers in some parts of the admin tool</li>
-        <li>interactive elements, such as drop-down menus, can update the page automatically</li>
         <li>checkboxes for applying settings to a service need to be tabbed through to select and deselect</li>
         <li>the function of some buttons is not clearly announced to screen readers</li>
-        <li>tabbing through the Services page to access a service’s dashboards may not work</li>
-        <li>links to change and edit account and service settings are not announced to screen readers</li>
-        <li>horizontally scrolling the page to find a prototype payment link, to test with paying users, may not work if the screen is magnified</li>
-        <li>viewing revoked API keys may not be possible for users using screen readers or only the keyboard</li>
-        <li>it may not be obvious that a payment link has been deleted</li>
       </ul>
 
       <h2 class="govuk-heading-m">What to do if you have difficulty using this service</h2>
@@ -83,16 +77,9 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
       <p class="govuk-body">For users in government service teams:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>field labels may not be announced to screen readers in some parts of the admin tool (WCAG success criteria 2.4.6 and 4.1.3)</li>
-        <li>interactive elements, such as drop-down menus, can update the page automatically (WCAG success criterion 3.1.1)</li>
         <li>the function of some buttons is not clearly announced to screen readers (WCAG success criteria 1.3.1 and 4.1.2)</li>
-        <li>tabbing through the services page to access a service’s dashboards may not (WCAG success criterion 2.4.7)</li>
-        <li>links to change and edit account and service settings are not announced to screen (WCAG success criterion 1.3.1)</li>
-        <li>horizontally scrolling the page to find a prototype payment link, to test with paying users, may not work if the screen is magnified (WCAG success criterion 1.4.10)</li>
-        <li>viewing revoked API keys may not be possible for users using screen readers or only the keyboard (WCAG success criterion 4.1.2)</li>
-        <li>it may not be obvious that a payment link has been deleted (WCAG success criterion 2.4.3)</li>
       </ul>
       <p class="govuk-body">We intend to fix these problems by 30 September 2020.</p>
-      <p class="govuk-body">Users in government service teams will find that checkboxes for applying settings to a service need to be tabbed through to select and deselect. We’re intending to diagnose and fix this issue by 31 December 2020.</p>
       <p class="govuk-body">Users in government service teams will find that checkboxes for applying settings to a service need to be tabbed through to select and deselect. We’re intending to diagnose and fix this issue by 31 December 2020.</p>
       <p class="govuk-body">Additionally the following content on <a class="govuk-link" href="https://payments.statuspage.io/">GOV.UK&nbsp;Pay’s status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -129,7 +116,7 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
       <p class="govuk-body">Our <a class="govuk-link" href="/roadmap/">roadmap</a> includes information about how and when we plan to improve accessibility on this service.</p>
       <p class="govuk-body">We know that if you take too long to submit information on a form, you will not receive a warning message or be able to extend your time. This is not compliant with the Web Content Accessibility Guidelines version 2.1 AAA standard, section 2.2.6.</p>
       <p class="govuk-body">We conducted an accessibility review in 2016 and found that setting a 90-minute timeout was more helpful for users with accessibility needs than a warning message. If we plan to do more research on this, it will be announced in our roadmap.</p>
-      <p class="govuk-body">This page was prepared on 10 September 2019. It was last updated on 22 September 2020.</p>
+      <p class="govuk-body">This page was prepared on 10 September 2019. It was last updated on 24 September 2020.</p>
 
     </div>
   </main>


### PR DESCRIPTION
We intend to make GOV.UK Pay compliant with the WCAG 2.1 AA standard as soon as possible and have been working on accessibility issues for the last few weeks. This PR removes the failures we've fixed since the statement was published on 22 September.

I also removed a duplicate paragraph.