### PR TITLE
Update roadmap with Q3 objectives

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -59,49 +59,52 @@ title: Roadmap
             </div>
              <h2 class="govuk-heading-m">Recently released</h2>
               <ul class="govuk-list govuk-list--bullet">
-                <li>3D Secure 2 support for Worldpay and ePDQ</li>
-                <li>View payments Stripe has made into your bank account</li>
-                <li>View and download all transactions from GOV.UK Pay services in one report</li>
-                <li>Add reporting columns to payment links, e.g. cost centre codes</li>
-                <li>CSV download limit increased from 10,000 to 100,000 transactions</li>
-                <li>Making it easier to handle card payments taken by agents over the phone (also known as <a class="govuk-link" href="https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments">MOTO payments</a>)</li>
                 <li>Making GOV.UK Pay more accessible for users</li>
-                <li>Trialling PCI advice sessions (contact us if you want more information)</li>
-                <li><a class="govuk-link" href="https://landing.google.com/sre/sre-book/chapters/service-level-objectives/#indicators-o8seIAcZ">Implementing service level objectives</a></li>
+                <li>Hide sensitive card details when call centre agents are working from home (a <a class="govuk-link" href="https://www.payments.service.gov.uk/take-payments-by-phone-or-post/">MOTO payments</a> feature)</li>
+                <li>Increased the <a class="govuk-link" href="https://docs.payments.service.gov.uk/custom_metadata/#add-custom-metadata">metadata</a> value limit from 50 to 100 characters</li>
+                <li>Reports on bank payouts from Stripe available via CSV and API</li>
+                <li>Performance improvements to the Transactions page in the <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/login">admin tool</a></li>
+                <li>Various operational improvements and bug fixes</li>
+
               </ul>
 
-             <h2 class="govuk-heading-m">July to September 2020</h2>
+             <h2 class="govuk-heading-m">Things we're working on</h2>
 
-              <p class="govuk-body">This quarter we’re focusing on work that improves the experience for paying users and service users of Pay, as well as work that supports GOV.UK Pay’s growth and makes it more efficient to run. This includes:</p>
+              <p class="govuk-body">We’re focusing on work that improves the experience for service users of GOV.UK Pay, as well as work that helps service teams be compliant with <a class="govuk-link" href="https://www.fca.org.uk/consumers/strong-customer-authentication">Strong Customer Authentication</a> regulations. We continue to do work that supports GOV.UK Pay’s growth and makes it more efficient to run.</p>
+              <p class="govuk-body">This includes:</p>
 
               <ul class="govuk-list govuk-list--bullet">
-                <li>Making it easier to manage multiple services in Pay</li>
-                <li>Making Stripe payout reports available via the API</li>
-                <li>Conducting an accessibility audit with the Digital Accessibility Centre</li>
-                <li>Making error messages and field validation more helpful for paying users</li>
-                <li>Supporting Welsh-language users to make a payment and receive a receipt</li>
+                <li>Making it easier for service teams to understand and start using Pay</li>
+                <li>Redesign the payments journey to reduce the number of abandoned payments</li>
+                <li>Doing further research into accessibility and where we might need to improve the experience for paying users</li>
+                <li>Making GOV.UK Pay’s infrastructure run even more efficiently</li>
                </ul>
 
-              <p class="govuk-body">We’re also working on:</p>
-
+            <h2 class="govuk-heading-m">Up next</h2>
               <ul class="govuk-list govuk-list--bullet">
-                <li>Making GOV.UK Pay’s infrastructure run even more efficiently by moving to <a class="govuk-link" href="https://www.cloud.service.gov.uk">GOV.UK Platform as a Service</a> and increasing observability of service performance</li>
-                <li>Working with Government Shared Services, Government Finance Function and Government Banking to make it easier for central government teams to start using Pay</li>
-                <li>Working with the <a class="govuk-link" href="https://localdigital.gov.uk/funding/barnsley-metropolitan-borough-council/">MHCLG-funded alpha</a>, led by Barnsley Council, into how to make income management easier in local government</li>
+                <li>Retry sending emails when GOV.UK Notify has an outage</li>
+                <li>Make our existing performance data publicly available</li>
+                <li>Support Welsh-language users to receive a receipt after making a payment</li>
               </ul>
 
-            <h2 class="govuk-heading-m">Later</h2>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>Automated phone payments (IVR) pilot</li>
-                <li>Support for processing and reporting on payments made via a call centre supplier</li>
-                <li>Open Banking research and discovery</li>
-                <li>Discovery into recurring payments</li>
-                <li>Improved support for services managing invoices</li>
-              </ul>
+              <h2 class="govuk-heading-m">Later</h2>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>Automated telephone payments (IVR) alpha and private beta</li>
+                  <li>Support for processing and reporting on payments made via a call centre supplier</li>
+                  <li>Discovery into recurring payments</li>
+                  <li>Improved support for services managing invoices</li>
+                </ul>
+
+                <h2 class="govuk-heading-m">Things we're exploring</h2>
+                  <ul class="govuk-list govuk-list--bullet">
+                    <li>Working with Government Shared Services, Government Finance Function and Government Banking to make it easier for central government teams to start using Pay</li>
+                    <li>Making income management easier in local government by working with the <a class="govuk-link" href="https://pipeline.localgov.digital/wiki/484/mhclg-local-digital-fund-alpha-project-exploring-income-management-and-e-pa#">MHCLG-funded alpha, led by Barnsley Council</a></li>
+                    <li>Making it easier for service teams to take and manage payments by Direct Debit by working with Government Finance Function and Government Banking Service</li>
+                  </ul>
 
             <h2 class="govuk-heading-m">Get in touch</h2>
             <p class="govuk-body"><a class="govuk-link" href="https://www.payments.service.gov.uk/support/">Let us know</a> if you'd like to be involved in research, if you have any questions, or there are other features you’d like us to develop.</p>
-            <p class="govuk-body"><a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLSdJRj0asGOu3VJZ-0UPmx0T6w7FMsdduRAS51k18TS2XlNC7w/viewform">Sign up to the GOV.UK Pay newsletter</a> to find out more.</p>
+            <p class="govuk-body"><a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLSdJRj0asGOu3VJZ-0UPmx0T6w7FMsdduRAS51k18TS2XlNC7w/viewform">Sign up to the GOV.UK Pay updates</a> to find out more about what we’re working on and our plans for the future.</p>
     </div>
   </main>
 </div>

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -68,7 +68,7 @@ title: Roadmap
 
               </ul>
 
-             <h2 class="govuk-heading-m">Things we're working on</h2>
+             <h2 class="govuk-heading-m">Things we’re working on</h2>
 
               <p class="govuk-body">We’re focusing on work that improves the experience for service users of GOV.UK Pay, as well as work that helps service teams be compliant with <a class="govuk-link" href="https://www.fca.org.uk/consumers/strong-customer-authentication">Strong Customer Authentication</a> regulations. We continue to do work that supports GOV.UK Pay’s growth and makes it more efficient to run.</p>
               <p class="govuk-body">This includes:</p>


### PR DESCRIPTION
There's a few changes in this PR.

Instead of referencing which quarter we're in, I've put 'Things we're working on'. I've also added a 'Things we're exploring' section to differentiate that work from feature work. I've also added an 'Up next' section, to show what we're likely to work on after meeting our main objectives.

I've made these changes because I'm hoping we can update this more regularly. A roadmap is a living document.