### PR TITLE
Add OpenGraph meta tags to show cards when sharing URLs

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -16,6 +16,11 @@
     <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+    <meta property="og:title" content="<%= current_page.data.title && %>">
+    <meta property="og:site_name" content="GOV.UK Pay">
+    <meta property="og:url" content="https://www.payments.service.gov.uk">
+    <meta property="og:description" content="<%= current_page.data.description %>">
+    <meta property="og:type" content="website">
     <meta property="og:image" content="/images/govuk-opengraph-image.png">
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@gdsteam" />

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -17,6 +17,13 @@
     <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
     <meta property="og:image" content="/images/govuk-opengraph-image.png">
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@gdsteam" />
+    <meta name="twitter:title" content="<%= current_page.data.title && "#{current_page.data.title} – " %>GOV.UK Pay" />
+    <% if current_page.data.description != '' %>
+    <meta name="twitter:description" content="<%= current_page.data.description %>" />
+    <% end %>
+    <meta name="twitter:image" content="/images/govuk-opengraph-image.png" />
 
     <%= stylesheet_link_tag :application, media: 'screen' %>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -24,10 +24,6 @@
     <meta property="og:image" content="/images/govuk-opengraph-image.png">
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@gdsteam" />
-    <meta name="twitter:title" content="<%= current_page.data.title && "#{current_page.data.title} – " %>GOV.UK Pay" />
-    <% if current_page.data.description != '' %>
-    <meta name="twitter:description" content="<%= current_page.data.description %>" />
-    <% end %>
 
     <%= stylesheet_link_tag :application, media: 'screen' %>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -28,7 +28,6 @@
     <% if current_page.data.description != '' %>
     <meta name="twitter:description" content="<%= current_page.data.description %>" />
     <% end %>
-    <meta name="twitter:image" content="/images/govuk-opengraph-image.png" />
 
     <%= stylesheet_link_tag :application, media: 'screen' %>
 


### PR DESCRIPTION
Bugs me that when we share URLs on Twitter the path gets cut off, so have added OpenGraph tags to show summary cards. Also means people don't have to decipher the URL when it's shared on Slack, they can read the OpenGraph summary card to understand what the page is about.

Just finished packing up the flat and had to wait around for someone, this seemed like a good way to pass the time.