### PR TITLE
Update 3D Secure page with latest developments

### DIFF
--- a/source/3d-secure-2.html.erb
+++ b/source/3d-secure-2.html.erb
@@ -93,7 +93,6 @@ title: GOV.UK Pay 3D Secure 2
       <p class="govuk-body">You may see a reduction in fraud on your service because users need to provide additional authentication before making a payment.</p>
       <p class="govuk-body">Services are not liable for fraudulent or unrecognised transactions if they are processed by 3DS2. If a user disputes a 3DS2 transaction (for example using a chargeback) on the basis that it is fraudulent or unrecognised, it is the responsibility of the bank to refund the customer if required, because the bank approved 3DS2 transactions.</p>
       <p class="govuk-body">Services are still liable for transactions that are exempt from 3DS2 and are responsible if a user disputes a transaction on the basis that they did not receive the goods or service they paid for.</p>
-      <p class="govuk-body">You don’t need to enable 3D Secure on telephone payment (MOTO) services.</p>
 
       <h2 class="govuk-heading-m">How to set up 3D Secure 2</h2>
       <p class="govuk-body">The way you set up 3DS2 will depend on your Payment Service Provider (PSP).</p>
@@ -102,7 +101,7 @@ title: GOV.UK Pay 3D Secure 2
       <p class="govuk-body">GOV.UK Pay is managing the 3DS2 integration with Stripe so you do not need to make any changes to your integration with us. Stripe will automatically apply exemptions.</p>
 
       <h3 class="govuk-heading-s">Worldpay</h3>
-      <p class="govuk-body">Worldpay are implementing 3DS2 as part of their 3DS Flex product. You will receive 3DS Flex credentials from Worldpay and <a class="govuk-link" href="https://docs.payments.service.gov.uk/set_up_3dsecure/#set-up-3ds2-3ds-flex">you will need to add them into your Pay service.</a></p>
+      <p class="govuk-body">Worldpay are implementing 3DS2 as part of their 3DS Flex product. You will receive 3DS Flex credentials from Worldpay and <a class="govuk-link" href="https://docs.payments.service.gov.uk/set_up_3dsecure/#set-up-3ds2-3ds-flex">you will need to add them into your Pay service</a>. You don’t need to enable 3D Secure on telephone payment (MOTO) services.</p>
       <p class="govuk-body">If you are a Government Banking customer, please email serviceteam.gbs@hmrc.gov.uk to get help enabling 3DS Flex on your account. We recommend that you do this soon as it provides a smoother experience for paying users.</p>
       <p class="govuk-body">If you have a direct contract with Worldpay (not via Government Banking), Worldpay can send you your 3DS Flex credentials so get in touch with your contact at Worldpay.</p>
       <p class="govuk-body">Worldpay will send all transactions via 3DS2 or 3DS. Worldpay does not apply exemptions by default but GOV.UK Pay supports Worldpay’s Exemption Engine. If you’d like to apply for exemptions for your transactions, <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact GOV.UK Pay</a> to chat through your needs.</p>

--- a/source/3d-secure-2.html.erb
+++ b/source/3d-secure-2.html.erb
@@ -44,20 +44,22 @@ title: GOV.UK Pay 3D Secure 2
             <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a class="govuk-link" href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
             </li>
-            <li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
               <a class="govuk-link" href="/security" itemprop="item"><span itemprop="name">Security and compliance</span></a>
+            </li>
+            <li class="sub-navigation__item sub-navigation__item--sub sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+              <a class="govuk-link" href="/3d-secure-2" itemprop="item"><span itemprop="name">Strong Customer Authentication</span></a>
             </li>
           </ol>
         </nav>
       </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Strong Customer Authentication: what it is and how it will work</h1>
-      <p class="govuk-body">Strong Customer Authentication (SCA) will make online payments more secure for users and reduce fraud. It is part of the Payment Service Directive (PSD2) as enforced by the Financial Conduct Authority.</p>
-      <p class="govuk-body">Services that take payments from the EU, Norway, Iceland and Liechtenstein (otherwise known as the European Economic Area, EEA), must implement SCA by 31 December 2020. Services that only take payments from within the UK need to implement SCA by 14 September 2021.</p>
-      <p class="govuk-body">Services implement SCA by implementing 3D Secure 2 (3DS2) or 3D Secure (3DS)</p>
-      <p class="govuk-body">3DS2 adds an extra layer of identity confirmation before the user pays so that transactions meet the SCA rules.</p>
-      <p class="govuk-body">3DS2 replaces 3DS. 3DS transactions offer a similar level of protection for users and are compliant with SCA requirements, but introduce more friction to the user journey. 3DS will also be phased out, though the date for this has not been confirmed.</p>
+      <h1 class="govuk-heading-l">Strong Customer Authentication: what it is and how it works</h1>
+      <p class="govuk-body">Strong Customer Authentication (SCA) aims to make online payments more secure for users and reduce fraud. It is part of the Payment Service Directive (PSD2) as enforced by the <a class="govuk-link" href="https://www.fca.org.uk/consumers/strong-customer-authentication">Financial Conduct Authority</a>.</p>
+      <p class="govuk-body">Services that take payments from the EU, Norway, Iceland and Liechtenstein (otherwise known as the European Economic Area, EEA), must meet SCA regulation by 31 December 2020. Services that only take payments from within the UK need to meet SCA regulation by 14 September 2021.</p>
+      <p class="govuk-body">Services meet SCA regulation by implementing 3D Secure 2 (3DS2) or 3D Secure (3DS) that adds an extra layer of identity confirmation before the user pays so that transactions meet the SCA rules.</p>
+      <p class="govuk-body">3DS2 replaces 3DS. 3DS transactions offer a similar level of protection for users and are compliant with SCA requirements, but 3DS2 reduces friction for users and leads to a smoother paying user experience. 3DS will also be phased out in 2022, though the exact date for this has not been confirmed.</p>
 
       <h2 class="govuk-heading-m">What 3D Secure 2 means for users</h2>
       <p class="govuk-body">3DS2 requires 2 factor authentication, and will ask users for 2 out of 3 pieces of information to complete their transaction:</p>
@@ -66,6 +68,8 @@ title: GOV.UK Pay 3D Secure 2
         <li>something the user has, for example their phone</li>
         <li>something the user knows, for example a password</li>
       </ul>
+
+      <p class="govuk-body">Usually this means the user will have to enter a short code sent by SMS by their bank.</p>
 
       <p class="govuk-body">Transactions processed through digital wallets (such as Apple Pay or Google Pay) meet the 2 factor authentication requirements.</p>
 
@@ -83,12 +87,13 @@ title: GOV.UK Pay 3D Secure 2
         <li>corporate payments (unless the corporate card is in the name of an individual)</li>
       </ul>
 
-      <p class="govuk-body">Which exemptions are applied will depend on your Payment Service Provider (PSP).</p>
+      <p class="govuk-body">Which exemptions are applied will depend on your Payment Service Provider (PSP). See ‘How to set up 3D Secure 2’ for more details.</p>
 
       <h2 class="govuk-heading-m">What 3D Secure 2 means for services</h2>
       <p class="govuk-body">You may see a reduction in fraud on your service because users need to provide additional authentication before making a payment.</p>
       <p class="govuk-body">Services are not liable for fraudulent or unrecognised transactions if they are processed by 3DS2. If a user disputes a 3DS2 transaction (for example using a chargeback) on the basis that it is fraudulent or unrecognised, it is the responsibility of the bank to refund the customer if required, because the bank approved 3DS2 transactions.</p>
       <p class="govuk-body">Services are still liable for transactions that are exempt from 3DS2 and are responsible if a user disputes a transaction on the basis that they did not receive the goods or service they paid for.</p>
+      <p class="govuk-body">You don’t need to enable 3D Secure on telephone payment (MOTO) services.</p>
 
       <h2 class="govuk-heading-m">How to set up 3D Secure 2</h2>
       <p class="govuk-body">The way you set up 3DS2 will depend on your Payment Service Provider (PSP).</p>
@@ -98,9 +103,9 @@ title: GOV.UK Pay 3D Secure 2
 
       <h3 class="govuk-heading-s">Worldpay</h3>
       <p class="govuk-body">Worldpay are implementing 3DS2 as part of their 3DS Flex product. You will receive 3DS Flex credentials from Worldpay and <a class="govuk-link" href="https://docs.payments.service.gov.uk/set_up_3dsecure/#set-up-3ds2-3ds-flex">you will need to add them into your Pay service.</a></p>
-      <p class="govuk-body">If you are a Government Banking customer, Government Banking will contact you to let you know when to enable 3DS Flex on your account.</p>
-      <p class="govuk-body">If you have a direct contract with Worldpay (not via Government Banking), Worldpay will send you your 3DS credentials.</p>
-      <p class="govuk-body">Worldpay will send all transactions via 3DS2 or 3DS. Worldpay does not apply exemptions by default. If you’d like to apply for exemptions for your transactions, <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact GOV.UK Pay.</a></p>
+      <p class="govuk-body">If you are a Government Banking customer, please email serviceteam.gbs@hmrc.gov.uk to get help enabling 3DS Flex on your account. We recommend that you do this soon as it provides a smoother experience for paying users.</p>
+      <p class="govuk-body">If you have a direct contract with Worldpay (not via Government Banking), Worldpay can send you your 3DS Flex credentials so get in touch with your contact at Worldpay.</p>
+      <p class="govuk-body">Worldpay will send all transactions via 3DS2 or 3DS. Worldpay does not apply exemptions by default but GOV.UK Pay supports Worldpay’s Exemption Engine. If you’d like to apply for exemptions for your transactions, <a class="govuk-link" href="https://www.payments.service.gov.uk/support/">contact GOV.UK Pay</a> to chat through your needs.</p>
 
       <h3 class="govuk-heading-s">Barclays ePDQ</h3>
       <p class="govuk-body">GOV.UK Pay has built the integration with 3DS2 for ePDQ. You will not need to make any changes to your integration. Exemptions (see above) will not be applied.</p>
@@ -123,10 +128,10 @@ title: GOV.UK Pay 3D Secure 2
         <li>make sure 3D Secure is activated in your <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/login">account settings</a> if you’re using Worldpay</li>
         <li>check with your PSP about any charges for 3D Secure 2</li>
         <li>activate Apple Pay and Google Pay in your account settings if you’re using Worldpay</li>
-        <li><a class="govuk-link" href="https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments">follow the instructions</a> if you use GOV.UK Pay to take phone payments - these are exempt from 3DS and 3DS2</li>
+        <li><a class="govuk-link" href="https://docs.payments.service.gov.uk/moto_payments/#take-a-payment-over-the-phone-moto-payments">follow the instructions</a> if you use GOV.UK Pay to take phone payments – these are exempt from 3DS and 3DS2</li>
       </ul>
 
-      <p class="govuk-body"><a class="govuk-link" href="/support/">Contact the GOV.UK Pay team</a> with any questions</p>
+      <p class="govuk-body"><a class="govuk-link" href="/support/">Contact the GOV.UK Pay team</a> with any questions.</p>
     </div>
    </div>
   </main>

--- a/source/3d-secure-2.html.erb
+++ b/source/3d-secure-2.html.erb
@@ -87,14 +87,14 @@ title: GOV.UK Pay 3D Secure 2
         <li>corporate payments (unless the corporate card is in the name of an individual)</li>
       </ul>
 
-      <p class="govuk-body">Which exemptions are applied will depend on your Payment Service Provider (PSP). See ‘How to set up 3D Secure 2’ for more details.</p>
+      <p class="govuk-body">Which exemptions are applied will depend on your Payment Service Provider (PSP). See <a class="govuk-link" href="#how-to-set-up-3d-secure">How to set up 3D Secure 2</a> for more details.</p>
 
       <h2 class="govuk-heading-m">What 3D Secure 2 means for services</h2>
       <p class="govuk-body">You may see a reduction in fraud on your service because users need to provide additional authentication before making a payment.</p>
       <p class="govuk-body">Services are not liable for fraudulent or unrecognised transactions if they are processed by 3DS2. If a user disputes a 3DS2 transaction (for example using a chargeback) on the basis that it is fraudulent or unrecognised, it is the responsibility of the bank to refund the customer if required, because the bank approved 3DS2 transactions.</p>
       <p class="govuk-body">Services are still liable for transactions that are exempt from 3DS2 and are responsible if a user disputes a transaction on the basis that they did not receive the goods or service they paid for.</p>
 
-      <h2 class="govuk-heading-m">How to set up 3D Secure 2</h2>
+      <h2 class="govuk-heading-m" id="how-to-set-up-3d-secure">How to set up 3D Secure 2</h2>
       <p class="govuk-body">The way you set up 3DS2 will depend on your Payment Service Provider (PSP).</p>
 
       <h3 class="govuk-heading-s">Stripe</h3>


### PR DESCRIPTION
- We know when 3DS1 is likely to be phased out
- We now support Worldpay's Exemption Engine
- Services are strongly encouraged to enable 3DS Flex (to get 3DS2 support) as soon as possible
- Most banks ask paying users to verify themselves with a code sent by SMS