### PR TITLE
PP-7701 - Update Cookies page -  update to describe the new 'govuk_pay_notifications' cookie

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -108,6 +108,11 @@ title: Cookies
             <td class="govuk-table__cell">Remembers your registration progress if you’ve been invited</td>
             <td class="govuk-table__cell">1 hour</td>
           </tr>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__cell govuk-table__head" scope="row">govuk_pay_notifications</th>
+            <td class="govuk-table__cell">Remember the notifications you’ve seen so we don’t show them again</td>
+            <td class="govuk-table__cell">6 months</td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
- Add text to explain the new 'govuk_pay_notifications' for  showing
  the `notification banner` on the `My Services` page.