### PR TITLE
PP-7766 Add 'Setting up Stripe test account' content

### DIFF
--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -83,6 +83,16 @@ title: GOV.UK Pay’s Payment Service Provider
         <p class="govuk-body">There are no overhead costs on the account. You don’t pay a management, set up or monthly fee. You just pay the transaction charges. Nothing more.</p>
         <p class="govuk-body">Transaction fees are commercially sensitive. Details are available in the contract when you sign in to your account.</p>
 
+        <h2 class="govuk-heading-m">Setting up a Stripe test account</h2>
+        <p class="govuk-body">You can test Stripe’s reporting before your service goes live. You can access the same reports and functionality as a live account, including:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>transaction fees</li>
+          <li>gross and net payments</li>
+          <li>payments into your bank account</li>
+        </ul>
+        <p class="govuk-body">Download the data as a .csv file or by integrating with our reporting and reconciliation API.</p>
+        <p class="govuk-body">Request a Stripe test account from your service's dashboard in the Admin tool.</p>
+
         <h2 class="govuk-heading-m">Setting up Stripe</h2>
         <p class="govuk-body">When you’re ready to go live, select ‘request a live account’ in your test account.</p>
         <p class="govuk-body">You’ll then:</p>


### PR DESCRIPTION
## WHAT
- Added 'Setting up a Stripe test account' section to GOV.UK Pay’s Payment Service Provider page