### PR TITLE
Update roadmap for April to July 2021

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -4,15 +4,15 @@ title: Roadmap
 <div class="govuk-width-container">
   <div class="govuk-breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
     <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="/">GOV.UK&nbsp;Pay</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page"><%= current_page.data.title %></a>
-        </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">GOV.UK&nbsp;Pay</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page"><%= current_page.data.title %></a>
+      </li>
     </ol>
   </div>
   <main id="main-content" class="govuk-main-wrapper" role="main">
@@ -50,72 +50,106 @@ title: Roadmap
           </ol>
         </nav>
       </div>
-
+      
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Roadmap</h1>
-            <p class="govuk-body">Here’s a list of the new and improved functionality we’re planning to offer through GOV.UK&nbsp;Pay.</p>
-            <div class="govuk-inset-text">
-              <p class="govuk-body">This roadmap is only a guide and may change. We work in 3-monthly cycles.</p>
-            </div>
-             <h2 class="govuk-heading-m">Recently released</h2>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>Protection for in-flight payments when switching between 3D Secure 1 and Worldpay’s 3DS Flex, so that users don’t have to retry payments</li>
-                <li>Security keys for 3DS Flex are checked when entered, so that users’ payments won’t be disrupted</li>
-                <li>Added support for Google Pay due to Strong Customer Authentication requirements</li>
-                <li>Made it easier to add reporting columns to payment links, for collecting data like cost centre codes</li>
-                <li>Made Stripe payout data available via API as well as CSV download</li>
-                <li>Improved guidance on for MOTO payments, custom branding and Strong Customer Authentication</li>
-                <li>Various operational improvements and bug fixes to make sure GOV.UK Pay is a reliable, available and secure service that performs well for services and paying users</li>
-              </ul>
-
-            <h2 class="govuk-heading-m">What we’ve learned through research</h2>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>The paying user experience supports users with accessible needs well, but entering long card numbers is confusing and time-consuming for users with cognitive impairments</li>
-                <li>We can add hint text to make it easier for paying users with cognitive impairments to enter the correct numbers first time around</li>
-                <li>All paying users would benefit from clearer warnings about the steps they’ll need to take in 3D Secure verification, which might also reduce the number of abandoned transactions</li>
-                <li>Finance and technical users would benefit from better guidance about how to manage reporting and reconciliation on their GOV.UK Pay service</li>
-              </ul>
-
-             <h2 class="govuk-heading-m">Things we’re working on</h2>
-
-              <p class="govuk-body">We’re focusing on delivering improvements to the experience for service users of GOV.UK Pay. We continue to do operational and performance work that supports GOV.UK Pay’s growth and makes it more efficient to run.</p>
-              <p class="govuk-body">This includes:</p>
-
-              <ul class="govuk-list govuk-list--bullet">
-                <li>making it easier for service teams to understand and start using Pay, through better content on our product pages and making our admin tool easier to navigate</li>
-                <li>making GOV.UK Pay’s infrastructure run even more efficiently</li>
-               </ul>
-
-              <p class="govuk-body">Alongside our delivery work, we’re also running two discoveries this quarter:</p>
-
-              <ul class="govuk-list govuk-list--bullet">
-                <li>to prioritise which payment types and channels we build to meet services’ needs for their paying users</li>
-                <li>to understand how GOV.UK Pay can support the new finance patterns and software changes in central government, to make reporting and reconciliation easier</li>
-               </ul>
-
-            <h2 class="govuk-heading-m">Up next</h2>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>Alphas based on what we’ve learned in our discoveries</li>
-                <li>Telephone payment links for services that can’t integrate with our API</li>
-              </ul>
-
-              <h2 class="govuk-heading-m">Later</h2>
-                <ul class="govuk-list govuk-list--bullet">
-                  <li>Improved support for services managing invoices</li>
-                  <li>Retry sending emails when GOV.UK Notify has an outage</li>
-                  <li>Make our existing performance data publicly available</li>
-                  <li>Support Welsh-language users to receive a receipt after making a payment</li>
-                </ul>
-
-                <h2 class="govuk-heading-m">Things we're exploring</h2>
-                  <ul class="govuk-list govuk-list--bullet">
-                    <li>Working with Government Shared Services, Government Finance Function and Government Banking to make it easier for central government teams to start using Pay</li>
-                    <li>How we might involve service teams more directly and frequently in prioritising our roadmap based on collective needs</li>
-                  </ul>
-
-            <h2 class="govuk-heading-m">Get in touch</h2>
-            <p class="govuk-body"><a class="govuk-link" href="https://www.payments.service.gov.uk/support/">Let us know</a> if you'd like to be involved in research, if you have any questions, or there are other features you’d like us to develop.</p>
+        <h1 class="govuk-heading-xl">Roadmap</h1>
+        <p class="govuk-body">Here’s a list of the new and improved functionality we’re planning to offer through GOV.UK&nbsp;Pay.</p>
+        <div class="govuk-inset-text">
+          <p class="govuk-body">This roadmap is only a guide and may change. We work in 3-monthly cycles.</p>
+        </div>
+        
+        <h2 class="govuk-heading-l">Recently released</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Added support for Worldpay’s <a class="govuk-link" href="https://developer.worldpay.com/docs/wpg/scaexemptionservices/exemptionengine">Exemption Engine</a>, so that paying users are less likely to need to complete 3D Secure challenges</li>
+          <li>Started a private beta phase for the new <a class="govuk-link" href="https://youtu.be/A6NAPQVwNOc?t=5598">‘telephone payment links’</a> product, which makes it easier for services without a technical team to start taking payments over the phone</li>
+          <li>Improved our caching to reduce page load times</li>
+          <li>Enabled users launching services on Stripe to plan their reconciliation process more easily. Users can download reports in their test account that illustrate fees as they will appear in their live account</li>
+          <li>Made it easier to <a class="govuk-link" href="https://docs.payments.service.gov.uk/account_structure/#setting-up-multiple-services">manage multiple services in GOV.UK Pay</a> by improving navigation in the admin tool and improving our documentation</li>
+          <li>Improved our content on how to get started with Pay and launched weekly <a class="govuk-link" href="https://docs.payments.service.gov.uk/support_contact_and_more_information/#support">demo and Q&A sessions</a> for new users</li>
+          <li>Made various operational improvements and bug fixes to make sure GOV.UK Pay is a reliable, available and secure service that performs well for services and paying users</li>
+        </ul>
+        
+        <h2 class="govuk-heading-l">What we’ve learned through research</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>We can support the <a class="govuk-link" href="https://www.gov.uk/government/publications/a-shared-services-strategy-for-government">Government Shared Services strategy</a> by helping departments to standardise payment processes and make them more efficient using GOV.UK Pay</li>
+          <li>There are high costs and lots of manual work involved with processing payments for invoices. We think GOV.UK Pay can help government save money by providing more support for taking payment for a debt and when an invoice is involved</li>
+          <li>There’s no good alternative for many of the use cases for Direct Debit, and lots of services would benefit from GOV.UK Pay providing it</li>
+          <li>Teams that had a need to take payments over the phone had a solution in place, whether through a call centre or in an automated way</li>
+          <li>There’s a lot of interest in Open Banking. We’re prioritising solving other problems first, but we want to hear from any organisations and services who have a problem they think GOV.UK Pay support for Pay by Bank might solve</li>
+          <li>The majority of teams we spoke to in our discovery had a need for recurring payments, whether simple renewals or recovering debt</li>
+        </ul>
+        
+        <h2 class="govuk-heading-l">Things we’re working on</h2>
+        
+        <h3 class="govuk-heading-m">Reprocurement of GOV.UK Pay’s payment service provider</h3>
+        <p class="govuk-body">GOV.UK Pay uses an underlying payment service provider to process card payments. Since 2019, GOV.UK Pay has provided a fully managed end-to-end service for card payments using a centralised contract with Stripe.</p>
+        
+        <h4 class="govuk-heading-s">Now</h4>
+        <p class="govuk-body">This contract ends in December 2021. We expect to procure a replacement contract in June 2021.</p>
+        
+        <h4 class="govuk-heading-s">Next</h4>
+        <p class="govuk-body">GOV.UK Pay will communicate the outcome and any relevant changes from June, including changes to transaction fees. If we change provider, we will integrate with them and switch all services currently using Stripe to the new provider by December 2021.</p>
+        
+        <h3 class="govuk-heading-m">Services can be easily transitioned to a new payment service provider</h3>
+        <p class="govuk-body">As we’re procuring a new payment service provider and ending support for bringing your own contract to GOV.UK Pay, we need to support services to switch between providers as easily as possible.</p>
+        
+        <h4 class="govuk-heading-s">Now</h4>
+        <p class="govuk-body">We’re building our understanding of how services will be impacted when moving between suppliers, so that we can develop a set of needs and design functionality to meet those needs.</p>
+        
+        <h4 class="govuk-heading-s">Next</h4>
+        <p class="govuk-body">We’ll build any functionality or tools needed to seamlessly transition services onto the new GOV.UK Pay provider or the Government Banking Service provider.</p>
+        
+        <h4 class="govuk-heading-s">Later</h4>
+        <p class="govuk-body">We’ll look at how we might better abstract services away from third party providers and improve our ability to switch so this becomes more efficient in future and enables frequent retendering of contracts.</p>
+        
+        <h3 class="govuk-heading-m">Users will be able to pay on a recurring basis</h3>
+        <p class="govuk-body">We’ve concluded our discovery into the new payment options that services need to support their users. We’ve decided to prioritise recurring payments first, meaning that users will be able to renew something or pay an invoice.
+          
+          <h4 class="govuk-heading-s">Now</h4>
+          <p class="govuk-body">We’re developing patterns for scheduling payments, updating payment details, cancelling payments, and resolving failed payments.</p>
+          
+          <h4 class="govuk-heading-s">Next</h4>
+          <p class="govuk-body">We’ll run a private beta meaning that a small number of services will be able to collect card payments for simple renewals, like garden waste subscriptions and fishing licence renewals.</p>
+          
+          <h4 class="govuk-heading-s">Later</h4>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Card payments for simple renewals will be available for all services using GOV.UK Pay</li>
+            <li>Users will be able to pay by Direct Debit and other methods</li>
+            <li>We’ll investigate the needs for paying large invoices in installments</li>
+          </ul>
+          <p class="govuk-body">Email <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a> if you’d like to be part of our research and testing. We’re planning to start a private beta phase in mid to late summer.</p>
+          
+          <h3 class="govuk-heading-m">Organisations will have better support for reconciling payments and processing invoices</h3>
+          <p class="govuk-body">We want to better support financial processes related to inbound payments. Enterprise resource planning (ERP) software is used as part of these processes in central government. As part of the <a class="govuk-link" href="https://www.gov.uk/government/publications/a-shared-services-strategy-for-government">Government Shared Services strategy</a>, departments are adopting cloud-based ERP software, creating new opportunities for GOV.UK Pay to make finance processes easier and cheaper.</p>
+          
+          <h4 class="govuk-heading-s">Now</h4>
+          <p class="govuk-body">We’ll work with two partner organisations to explore two-way communication between ERP software and GOV.UK Pay to ensure high quality data and seamless transfer of data.</p>
+          
+          <h4 class="govuk-heading-s">Next</h4>
+          <p class="govuk-body">We’ll start working with more organisations and gain a better understanding of other ERP platforms being used within government. We’ll support smaller organisations with improvements to payment links to make it easier to match payments to bank deposits.</p>
+          
+          <h4 class="govuk-heading-s">Later</h4>
+          <p class="govuk-body">We’ll integrate with the ERP software used by all central government clusters, automating reconciliation of payments accepted through GOV.UK Pay.</p>
+          <p class="govuk-body">We’ll look at how we can improve the end to end journey for payments, including how we could help to design better patterns for invoicing. 
+            
+            <h3 class="govuk-heading-m">Other improvements</h3>
+            
+            <h4 class="govuk-heading-s">Now</h4>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>We’ll continue to make infrastructure improvements to make GOV.UK Pay more reliable, cheaper to run, and easier to support and iterate</li>
+              <li>We’ll continue to make improvements to our documentation to make it easier to understand how to use GOV.UK Pay</li>
+            </ul>
+            
+            <h4 class="govuk-heading-s">Later</h4>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Put all notification emails on a queue, so that users can receive payment and refund confirmation emails even if GOV.UK Notify has an outage</li>
+              <li>Support Welsh-language users to receive payment and refund confirmation emails, so that the experience is consistent and bilingual</li>
+              <li>Redesign the user journey for card payments to make it easier for users with accessible needs and to reduce the number of abandoned transactions</li>
+            </ul>
+            
+            <h2 class="govuk-heading-l">Get in touch</h2>
+            <p class="govuk-body">Email <a class="govuk-link" href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a> if you'd like to be involved in research, if you have any questions, or there are other features you’d like us to develop.</p>
             <p class="govuk-body"><a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLSdJRj0asGOu3VJZ-0UPmx0T6w7FMsdduRAS51k18TS2XlNC7w/viewform">Sign up to the GOV.UK Pay updates</a> to find out more about what we’re working on and our plans for the future.</p>
-    </div>
-  </main>
-</div>
+          </div>
+        </main>
+      </div>


### PR DESCRIPTION
Have added an extra heading level to this version of the roadmap, meaning that some of the classes for headings have changed, e.g. govuk-heading-l has gone up to govuk-heading-xl, govuk-heading-m has gone up to govuk-heading-l, etc. This is so that we could introduce govuk-heading-s for h4s.