### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": "package-lock.json",
-    "lines": null
-  },
-  "generated_at": "2020-09-02T08:39:27Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,20 +53,71 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "source/layouts/layout.erb": [
       {
-        "hashed_secret": "ee5048791fc7ff45a1545e24f85bec3317371327",
-        "is_secret": false,
+        "type": "Base64 High Entropy String",
+        "filename": "source/layouts/layout.erb",
+        "hashed_secret": "f9ba52490176c0bc5626c80f332a8c2157b22867",
         "is_verified": false,
-        "line_number": 24,
-        "type": "Base64 High Entropy String"
+        "line_number": 31
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T15:03:43Z"
 }

--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -38,10 +38,10 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
       <p class="govuk-body"><a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to use if you have a disability.</p>
 
       <h2 class="govuk-heading-m">How accessible this service is</h2>
-      <p class="govuk-body">Some people may find parts of this service difficult to use.</p>
-      <p class="govuk-body">For paying users:</p>
+
+      <p class="govuk-body">Some parts of the <a class="govuk-link" href="https://payments.statuspage.io/">GOV.UK&nbsp;Pay’s status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>error messages and labels for card expiry dates may not be announced to screen readers</li>
+        <li>‘Subscribe to updates’ link and form may not fully announce to screen readers </li>
       </ul>
 
       <h2 class="govuk-heading-m">What to do if you have difficulty using this service</h2>
@@ -64,14 +64,8 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
       <p class="govuk-body">The content listed below is non-accessible for the following reasons.</p>
 
       <h3 class="govuk-heading-s">Non compliance with the accessibility regulations</h3>
-      <p class="govuk-body">For paying users:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>error messages and labels for card expiry dates may not be announced to screen readers (WCAG success criterion 4.1.3)</li>
-      </ul>
 
-      <p class="govuk-body">We intend to fix this problem by 31 July 2021.</p>
-
-      <p class="govuk-body">Additionally the following content on <a class="govuk-link" href="https://payments.statuspage.io/">GOV.UK&nbsp;Pay’s status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:</p>
+      <p class="govuk-body">The following content on <a class="govuk-link" href="https://payments.statuspage.io/">GOV.UK&nbsp;Pay’s status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>‘Subscribe to updates’ link does not contain programmatically discernible link text (WCAG success criterion 1.3.1)</li>
         <li>‘Subscribe to updates’ form fields do not contain an explicit label (WCAG success criterion 1.3.1)</li>


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`