### PR TITLE
PP-8519 Google Analytics - Set domain on Google Analytics cookie

### DIFF
--- a/source/pay-product-page/javascripts/analytics/init.js
+++ b/source/pay-product-page/javascripts/analytics/init.js
@@ -13,6 +13,7 @@ window.GovUkPay.InitAnalytics = (function () {
     // for custom dimensions, virtual pageviews and events
     window.GovUkPay.analytics = window.GovUkPay.Analytics.SetupAnalytics({
       trackingId: TRACKING_ID,
+      cookieDomain: window.GovUkPay.Cookie.getCookieDomain(),
       anonymizeIp: true,
       displayFeaturesTask: null,
       transport: "beacon",

--- a/source/pay-product-page/javascripts/analytics/init.test.js
+++ b/source/pay-product-page/javascripts/analytics/init.test.js
@@ -22,6 +22,10 @@ beforeAll(() => {
     SetupAnalytics: jest.fn(),
     TrackPageview: jest.fn(),
   }
+
+  window.GovUkPay.Cookie = {
+    getCookieDomain: jest.fn(),
+  } 
     
 })
 


### PR DESCRIPTION
- Fix issue with domain for Google Analytics cookie.
- Set the domain when running the command `ga('create'...)`