### PR TITLE
ZD-4848316 Remove outdated text about PSP reprocurement

### DIFF
--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -65,9 +65,6 @@ title: GOV.UK Pay’s Payment Service Provider
         </ul>
 
         <h2 class="govuk-heading-m">Using our PSP</h2>
-        <div class="govuk-inset-text">
-          We are currently re-procuring our PSP and expect to award to our chosen provider in June 2021. This may result in a change of provider.
-        </div>
         <p class="govuk-body">To get your service live, you need to accept GOV.UK Pay and Stripe contracts. <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/login">Sign in to your Pay account</a>, and you'll find them in the page footer. The negotiated transaction fees are in the contract.</p>
         <p class="govuk-body">If you already have a contract with Stripe, you cannot use it with GOV.UK Pay. You need to accept GOV.UK Pay's contract and terms.</p>
 


### PR DESCRIPTION
https://www.payments.service.gov.uk/payment-service-provider/

Remove outdated text about PSP reprocurement, which mentions June 2021 as if it’s in the future.