### PR TITLE
BAU — Check in build directory when building release tarball

### DIFF
--- a/lib/github-release/github-release.sh
+++ b/lib/github-release/github-release.sh
@@ -57,6 +57,13 @@ githubrelease_command_publish ()
     test ! -d build && bundle exec middleman build
 
     cd build
+    current_directory=$(basename "$PWD")
+
+    if [ $current_directory != "build" ]; then
+        critical "github-release" "We do not seem to be in the build directory"
+        exit 1
+    fi
+
     githubrelease_generate_package_json_file
     tar -cvzf pay-product-page-$githubrelease_option_version.tgz .
                                


### PR DESCRIPTION
For some reasons, sometimes when I do a release, the script the creates a tarball not of the `build` directory but of the directory above, which at that point does not seem to contain a `build` directory. It then merrily uploads this to GitHub. This is kind of dangerous, so check we’re actually in the `build` directory before creating the tarball.