### PR TITLE
PP-9289 Accessibility statement - Country select autocomplete

### DIFF
--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -61,6 +61,8 @@ title: Accessibility statement for GOV.UK&nbsp;Pay
 
       <h3 class="govuk-heading-s">Non-compliance with the accessibility regulations</h3>
 
+      <p class="govuk-body">You cannot use autocomplete to populate the country field on our payment pages. This is to ensure that the country used is from the GOV.UK Pay validated dataset. Most users will not be affected, as United Kingdom is the default value.</p>
+
       <p class="govuk-body">The following content on <a class="govuk-link" href="https://payments.statuspage.io/">GOV.UK&nbsp;Pay’s status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are listed below:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>‘Subscribe to updates’ link does not contain programmatically discernible link text (WCAG success criterion 1.3.1)</li>


### PR DESCRIPTION
- Add information about why the user cannot use `autocomplete`
  on the Payment pages > country select.
- This is because we want to make sure the country name used is
  from the GOV.UK validated dataset.
- Most users will not be affected by this because the default value
  is `United Kingdom`.