### PR TITLE
BAU remove hyperlinks to confidential docs

### DIFF
--- a/source/security.html.erb
+++ b/source/security.html.erb
@@ -59,13 +59,13 @@ title: Security and compliance
 
         <p class="govuk-body">GOV.UK Pay provides a safe and Payment Card Industry (PCI) compliant platform to process card payments.</p>
 
-        <p class="govuk-body">You can find more information about our security and compliance in the <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/memorandum-of-understanding-for-crown-bodies" data-click-events data-click-category="Content" data-click-action="External link clicked">memorandum of understanding (for crown bodies)</a> and <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/contract-for-non-crown-bodies" data-click-events data-click-category="Content" data-click-action="External link clicked">contract (for non-crown bodies</a>, for example local authorities and the NHS). These are available in the footer when you sign in to your account.</p>
+        <p class="govuk-body">You can find more information about our security and compliance in the memorandum of understanding (for crown bodies) and contract (for non-crown bodies, for example local authorities and the NHS). These are available in the footer when you sign in to your account.</p>
 
         <h2 class="govuk-heading-m">PCI compliance</h2>
 
         <p class="govuk-body">GOV.UK Pay is certified as a level 1 service provider with the Payment Card Industry Data Security Standard (PCI DSS) version 3.2.1. The PCI DSS provides guidance to help maintain payment security.</p>
 
-        <p class="govuk-body">If you need to see our <a class="govuk-link" href="https://selfservice.payments.service.gov.uk/policy/download/pci-dss-attestation-of-compliance" data-click-events data-click-category="Content" data-click-action="External link clicked">proof of our compliance</a> (also known as ‘attestation of compliance’), just sign in to your test account and you’ll find a link to it in the footer.</p>
+        <p class="govuk-body">If you need to see our proof of our compliance (also known as ‘attestation of compliance’), just sign in to your test account and you’ll find a link to it in the footer.</p>
 
         <p class="govuk-body">If you’d like to <a class="govuk-link" href="https://www.payments.service.gov.uk/take-payments-by-phone-or-post/">take payments by phone or post</a>, you’ll also need to be PCI compliant. Before you can take payments like this, you’ll need to show us proof of your PCI compliance.</p>
 


### PR DESCRIPTION
- these documents are confidential and should be only available to authenticated users.