### PR TITLE
PP-10242 Footer - link to the Self service privacy notice

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -146,7 +146,7 @@
             <h2 class="govuk-visually-hidden">Support links</h2>
               <ul class="govuk-footer__inline-list">
                 <li class="govuk-footer__inline-list-item">Built by the <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
-                <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/privacy">Privacy notice</a></li>
+                <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="https://selfservice.payments.service.gov.uk/privacy">Privacy notice</a></li>
                 <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/cookies">Cookies</a></li>
                 <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/accessibility-statement">Accessibility statement</a></li>
               </ul>


### PR DESCRIPTION
- The privacy notice hosted on `pay-product-page` was updated to be specific for paying users only
  - The payment pages will continue to link to this privacy notice.
- A new privacy notice was added to `self service` specifically for public sector users.
- Therefore, the `footer` privacy notice link is updated to  link to the `self service > privacy notice`