### PR TITLE
BAU — Change ‘WorldPay’ to ‘Worldpay’ in privacy policy

### DIFF
--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -167,7 +167,7 @@ title: Privacy notice
         <ul class="govuk-list govuk-list--bullet">
           <li>
             <%=
-              link_to 'WorldPay Privacy Policy',
+              link_to 'Worldpay Privacy Policy',
                       'https://www.fisglobal.com/-/media/fisglobal/files/pdf/policy/privacy/worldpay-privacy-notice-english.pdf?la=en',
                       class: 'govuk-link'
             %>


### PR DESCRIPTION
This matches the capitalisation in Worldpay’s privacy policy.