### PR TITLE
BAU — Remove rogue &nbsp; non-breaking space entities in non-HTML

### DIFF
--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Accessibility statement for GOV.UK&nbsp;Pay
+title: Accessibility statement for GOV.UK Pay
 ---
 
 <div class="govuk-width-container">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,6 @@
 ---
 hero: true
-description: Take and process online payments from your users - GOV.UK&nbsp;Pay is a free and secure online payment service for government and public sector organisations.
+description: Take and process online payments from your users - GOV.UK Pay is a free and secure online payment service for government and public sector organisations.
 ---
 
 <div class="masthead">

--- a/source/payment-service-provider.html.erb
+++ b/source/payment-service-provider.html.erb
@@ -1,5 +1,5 @@
 ---
-title: GOV.UK&nbsp;Pay’s Payment Service Provider
+title: GOV.UK Pay’s Payment Service Provider
 ---
 
 <div class="govuk-width-container">

--- a/source/police.html.erb
+++ b/source/police.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Using GOV.UK&nbsp;Pay to take and process payments for the police force
+title: Using GOV.UK Pay to take and process payments for the police force
 ---
 
 <div class="govuk-width-container">

--- a/source/using-govuk-pay.html.erb
+++ b/source/using-govuk-pay.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Using GOV.UK&nbsp;Pay
+title: Using GOV.UK Pay
 ---
 
 <div class="govuk-width-container">


### PR DESCRIPTION
Remove `&nbsp;` non-breaking space entities in parts of the pages that are not actually HTML.