### PR TITLE
Revert "PP-11087: Fix `security.txt` redirect"

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -65,11 +65,6 @@ end
 sprockets.append_path File.join(root, "node_modules/govuk-frontend/")
 sprockets.append_path File.join(root, "node_modules/gaap-analytics/build")
 
-# Special handling for redirecting to security.txt as it is a non-html content type.
-page "/security.txt", content_type: "text/html"
-redirect "security.txt", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
-redirect "security.txt.html", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
-
 redirect "contact/index.html", to: "/support/"
 redirect "features.html", to: "/using-govuk-pay/"
 redirect "payment-links.html", to: "/govuk-payment-pages/"


### PR DESCRIPTION
Reverts alphagov/pay-product-page#665

Following changes made to attempt to redirect requests for security.txt, the post-merge build was failing (https://github.com/alphagov/pay-product-page/actions/runs/5657995556/job/15328352441)

Discussed with @SandorArpa @sfount @stephencdaly @richblake. As this has been blocking changes on this repo, we are reverting the change and will reassess.

