### PR TITLE
PP-11087 Fix redirecting security text to cabinet office

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -65,9 +65,6 @@ end
 sprockets.append_path File.join(root, "node_modules/govuk-frontend/")
 sprockets.append_path File.join(root, "node_modules/gaap-analytics/build")
 
-# Special handling for redirecting to security.txt as it is a non-html content type.
-page "/security.txt", content_type: "text/html"
-redirect "security.txt", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
 redirect "security.txt.html", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
 
 redirect "contact/index.html", to: "/support/"


### PR DESCRIPTION
Following on from the good work done in
https://github.com/alphagov/pay-product-page/pull/665

Address the build issues, keep the rule that should work with the static GitHub Pages deployment.

Specifying `.txt.html` instructs the static file generated to use the appropriate `Content-Type` for the snipper 
of HTML that is generated to appropriately redirect the user accessing this path.

This removes the other instructions as they collide with the existing `/security` page (otherwise defined in this repo) and cause the build to fail.

Note the `page` config seems to only instruct the `middleman serve` process, not the static files generated -- this isn't validated but the behaviour suggests it.

Supersedes https://github.com/alphagov/pay-product-page/pull/668