### PR TITLE
PP-11338 add build static website to PR

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run tests and static build
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   run-tests:
-    name: Unit tests
+    name: Unit tests and static build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +25,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - name: Install dependencies
+      - name: Install npm dependencies
         run: npm ci
       - name: Run tests
         run: npm test
+      - name: Build static site
+        run: bundle exec middleman build --verbose

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-tests:
-    name: Unit tests
+    name: Unit tests and static build
     uses: ./.github/workflows/run-tests.yml
   static:
     name:  Deploy and release Pay product pages


### PR DESCRIPTION
For a recent story, building the website failed but the PR was only blocked when the the post-merge build and release Github action workflow was run.

We should add a GitHub actions check to PR builds to ensure the products pages can be built using bundle exec middleman build. It would also be useful to run with the --verbose flag, otherwise the cause of a failure might not be shown.

- add build static website to PR test