### PR TITLE
BAU — Remove gateway_account cookie

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -121,11 +121,6 @@ title: Cookies
               <td class="govuk-table__cell">3 hours</td>
             </tr>
             <tr class="govuk-table__row">
-              <th class="govuk-table__cell govuk-table__head" scope="row">gateway_account</th>
-              <td class="govuk-table__cell">Remembers the gateway account you last used, if you've signed in before</td>
-              <td class="govuk-table__cell">1 month</td>
-            </tr>
-            <tr class="govuk-table__row">
               <th class="govuk-table__cell govuk-table__head" scope="row">register_invite</th>
               <td class="govuk-table__cell">Remembers your registration progress if you’ve been invited</td>
               <td class="govuk-table__cell">1 hour</td>
@@ -176,11 +171,11 @@ title: Cookies
           <div class="cookie-settings__no-js">
             <h2 class="govuk-heading-s govuk-!-margin-top-6">Do you want to accept analytics cookies?</h2>
             <p class="govuk-body">
-              We use Javascript to set our analytics cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:
+              We use JavaScript to set our analytics cookies. Unfortunately JavaScript is not running on your browser, so you cannot change your settings. You can try:
             </p>
             <ul class="govuk-list govuk-list--bullet">
               <li>reloading the page</li>
-              <li>turning on Javascript in your browser</li>
+              <li>turning on JavaScript in your browser</li>
             </ul>
           </div>
 


### PR DESCRIPTION
Remove the gateway_account cookie from the [cookies](https://www.payments.service.gov.uk/cookies/) page because we stopped using this cookie a year ago (PP-10413).

Also change ‘Javascript’ to ‘JavaScript’ per https://www.gov.uk/guidance/style-guide/technical-content-a-to-z, which says: “Capital J, capital S.”