### PR TITLE
Update crown assets and govuk-frontend to v4.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'middleman', '~> 4.5.0'
 gem 'middleman-livereload'
 gem 'middleman-sprockets'
 gem 'sprockets', '~> 4.2.0'
-gem 'sassc'
+gem 'sassc-embedded'
 gem 'webrick'
 # you might need this if you're on a Mac `bundle config build.eventmachine --with-openssl-dir=/usr/bin/openssl`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    abbrev (0.1.2)
+    activesupport (7.0.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     backports (3.24.1)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.2.2)
-    contracts (0.17)
-    dotenv (2.8.1)
+    concurrent-ruby (1.2.3)
+    contracts (0.16.1)
+    dotenv (3.0.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    execjs (2.8.1)
+    execjs (2.9.1)
     fast_blank (1.0.1)
-    fastimage (2.2.6)
-    ffi (1.15.5)
-    haml (6.1.1)
+    fastimage (2.3.0)
+    ffi (1.16.3)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
+    haml (6.3.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -41,20 +44,20 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     memoist (0.16.2)
-    middleman (4.5.0)
+    middleman (4.5.1)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (>= 2.3.0)
-      middleman-cli (= 4.5.0)
-      middleman-core (= 4.5.0)
-    middleman-cli (4.5.0)
-      thor (>= 0.17.0, < 2.0)
-    middleman-core (4.5.0)
+      middleman-cli (= 4.5.1)
+      middleman-core (= 4.5.1)
+    middleman-cli (4.5.1)
+      thor (>= 0.17.0, < 1.3.0)
+    middleman-core (4.5.1)
       activesupport (>= 6.1, < 7.1)
       addressable (~> 2.4)
       backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13)
+      contracts (~> 0.13, < 0.17)
       dotenv
       erubis
       execjs (~> 2.0)
@@ -81,31 +84,38 @@ GEM
     middleman-sprockets (4.1.1)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
-    minitest (5.20.0)
+    minitest (5.22.2)
     padrino-helpers (0.15.3)
       i18n (>= 0.6.7, < 2)
       padrino-support (= 0.15.3)
       tilt (>= 1.4.1, < 3)
     padrino-support (0.15.3)
-    parallel (1.23.0)
+    parallel (1.24.0)
     parslet (2.0.0)
     prettier_print (1.2.1)
-    public_suffix (5.0.1)
-    rack (2.2.7)
+    public_suffix (5.0.4)
+    rack (2.2.8.1)
     rack-livereload (0.3.17)
       rack
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (3.1.0)
-    rexml (3.2.5)
+    rbs (3.4.4)
+      abbrev
+    rexml (3.2.6)
+    sass-embedded (1.71.1-arm64-darwin)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.71.1-x86_64-linux)
+      google-protobuf (~> 3.25)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-embedded (1.70.0)
+      sass-embedded (~> 1.70)
     servolux (0.13.0)
-    sprockets (4.2.0)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    syntax_tree (6.1.1)
+    syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     syntax_tree-haml (4.0.3)
       haml (>= 5.2)
@@ -115,8 +125,8 @@ GEM
       prettier_print
       rbs
       syntax_tree (>= 2.0.1)
-    temple (0.10.0)
-    thor (1.2.1)
+    temple (0.10.3)
+    thor (1.2.2)
     tilt (2.0.11)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
@@ -127,14 +137,15 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  ruby
+  arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   middleman (~> 4.5.0)
   middleman-livereload
   middleman-sprockets
   prettier_print
-  sassc
+  sassc-embedded
   sprockets (~> 4.2.0)
   syntax_tree
   syntax_tree-haml

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "gaap-analytics": "^3.1.0",
-        "govuk-frontend": "^3.14.0"
+        "govuk-frontend": "^4.8.0"
       },
       "devDependencies": {
         "@percy/cli": "^1.26.0",
@@ -2508,9 +2508,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -6843,9 +6843,9 @@
       "dev": true
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://www.payments.service.gov.uk",
   "dependencies": {
     "gaap-analytics": "^3.1.0",
-    "govuk-frontend": "^3.14.0"
+    "govuk-frontend": "^4.8.0"
   },
   "devDependencies": {
     "@percy/cli": "^1.26.0",


### PR DESCRIPTION
adds a [shim compiler](https://github.com/sass-contrib/sassc-embedded-shim-ruby) to fix broken sass complication with sourcemaps introduced in govuk-frontend v4.8
This now brings new crown assets in (favicon, etc) but as these pages use govuk-frontend v3 manual fixes are required to address styling tweaks 
<img width="1326" alt="Screenshot 2024-02-22 at 15 13 29" src="https://github.com/alphagov/pay-product-page/assets/3758555/14740504-8cd2-4f3a-b313-e15e85bb4c49">

