### PR TITLE
PP-12761: Rename default branch

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: Static
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -3,12 +3,12 @@ name: Visual regression
 on:
   pull_request:
     branches:
-      - 'master'
+      - 'main'
     paths:
       - 'source/**'
   push:
     branches:
-      - 'master'
+      - 'main'
     paths:
       - 'source/**'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Look at the CSS for the individual components for usage examples and notes.
 
 ## Releasing a Static Copy of the Site
 
-Releases are created when changes are merged into the `master` branch.
+Releases are created when changes are merged into the `main` branch.
 
 The product pages are then deployed to GitHub Pages automatically via GitHub Actions. Page contents are cached for roughly 30 minutes so your changes might not be viewable immediately.
 


### PR DESCRIPTION
Long overdue renaming of the default branch, to avoid outdated language and be consistent with our other repositories. 

~I'll rename the branch in the settings shortly after creating this PR.~ The branch has now been renamed to `main`.

This PR changes the post-deploy and visual regression workflows to trigger on merges to the main branch.
