### PR TITLE
PP-12053 Change accessibility statement updated date to 28 October

### DIFF
--- a/source/accessibility-statement.html.erb
+++ b/source/accessibility-statement.html.erb
@@ -127,7 +127,7 @@ title: Accessibility statement for GOV.UK Pay
         <p class="govuk-body">
           Our <%= link_to 'roadmap', 'roadmap', class: 'govuk-link' %> includes information about how and when we plan to improve accessibility on this service.
         </p>
-        <p class="govuk-body">This page was created on 10 September 2019. It was last updated on 24 October 2024.</p>
+        <p class="govuk-body">This page was created on 10 September 2019. It was last updated on 28 October 2024.</p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Change the last updated date of the accessibility statement to 28 October 2024 since that’s the date the revised version actually went live.