### PR TITLE
PP-12244: Resolve GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Ruby
-        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2
+        uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0
         with:
           ruby-version: '.ruby-version'
           bundler-cache: true
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Ruby
-        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2
+        uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0
         with:
           ruby-version: '.ruby-version'
           bundler-cache: true
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,14 +40,14 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Setup Pages
-        uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Get Package version
         id: get-package-version
         run: |
           echo "package_version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Get latest release version
         id: get-latest-release-version
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
@@ -101,7 +101,7 @@ jobs:
             .
       - name: Create Release
         id: create-release
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -126,11 +126,11 @@ jobs:
               throw err
             }
       - name: Upload Pages artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: 'github-pages'
           path: ${{ steps.set-artifact-name.outputs.name }}.tar
           retention-days: 7
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Ruby
-        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2
+        uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0
         with:
           ruby-version: '.ruby-version'
           bundler-cache: true
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Updates the following actions:

- `actions/checkout`
- `actions/setup-node`
- `ruby/setup-ruby` (3rd party safelist has been updated in the settings)
- `actions/configure-pages`
- `actions/github-script`
- `actions/upload-artifact` and `actions/deploy-pages` (need to be upgraded together for compatibility)

The post-merge workflow action upgrades worked OK for the team manual (see https://github.com/alphagov/pay-team-manual/pull/2203), so I'm reasonably confident they won't break the deployment here either.