### PR TITLE
PP-12687: Add dependency review checks

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -1,7 +1,6 @@
 name: Run tests and static build
 
 on:
-  pull_request:
   workflow_call:
   workflow_dispatch:
 
@@ -9,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  run-tests:
+  tests:
     name: Unit tests and static build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   tests:
     name: Unit tests and static build
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,11 @@
+name: PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/_run-tests.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,3 +9,7 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/_run-tests.yml
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   run-tests:
     name: Unit tests and static build
-    uses: ./.github/workflows/run-tests.yml
+    uses: ./.github/workflows/_run-tests.yml
   static:
     name:  Deploy and release Pay product pages
     needs: run-tests


### PR DESCRIPTION
We want to run the [shared `dependency-review` action workflow](https://github.com/alphagov/pay-ci/pull/1329) on pull requests in this repository, to replace the existing Snyk checks.

The main app repositories have a dedicated `pr.yml` workflow file, with a shared `_run-tests.yml` workflow called pre- and post-merge. 

In an attempt to get the repository workflows in a consistent state, I've:

- added a new `pr.yml` workflow
- renamed the `run-tests` job to `tests`
- added a call to the `detect-secrets` workflow as it was missing from this repo

Finally, I've included the `dependency-review` action in the `pr.yml` workflow.

I've kept `visual-regression.yml` as a separate workflow file as it is only triggered on certain PRs.

**Note**: Moving the tests workflow also means adjusting the required checks on `main` branch protection settings (see below for the check that's `Expected — Waiting for status to be reported`). Once this PR is approved I'll switch to the new version and the PR will be mergeable.