### PR TITLE
BAU update performance stats 09.12.2024 bis

### DIFF
--- a/data/performance.json
+++ b/data/performance.json
@@ -3,7 +3,7 @@
   "numberOfPayments": "95.3 million",
   "totalPaymentAmount": "6.1 billion",
   "numberOfServices": 1181,
-  "numberOfOrganisations": 433,
+  "numberOfOrganisations": 431,
   "serviceCountBySector": {
     "local": 534,
     "central": 277,


### PR DESCRIPTION
With the previous commit, we have already update the performance stats for this week, however we did aggregate services having similar organisation name, using the official name.

With this change, we are correcting the count of organisations, having corrected the name of the organisations directly in Toolbox and re-generated the count.