### PR TITLE
PP-13688 Fix Worldpay privacy policy link

### DIFF
--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -36,7 +36,7 @@ title: Privacy notice
       </div>
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l" id="heading-1">Privacy notice</h1>
-        <p class="govuk-body-l">Last updated: 17 January 2023</p>
+        <p class="govuk-body-l">Last updated: 7 April 2025</p>
 
         <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
         <p class="govuk-body">
@@ -166,11 +166,7 @@ title: Privacy notice
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            <%=
-              link_to 'Worldpay Privacy Policy',
-                      'https://www.fisglobal.com/-/media/fisglobal/files/pdf/policy/privacy/worldpay-privacy-notice-english.pdf?la=en',
-                      class: 'govuk-link'
-            %>
+            <%= link_to 'Worldpay Privacy Policy', 'https://privacy.worldpay.com/policies/en/', class: 'govuk-link' %>
           </li>
           <li>
             <%= link_to 'Stripe Privacy Policy', 'https://stripe.com/en-gb/privacy', class: 'govuk-link' %>


### PR DESCRIPTION
In our privacy policy, update the link to Worldpay’s privacy policy from the current URL (which no longer exists) to the new [Worldpay Privacy Center](https://privacy.worldpay.com/policies/en).