### PR TITLE
PP-13953 Update description metadata for main page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,6 @@
 ---
 hero: true
-description: Take and process online payments from your users - GOV.UK Pay is a free and secure online payment service for government and public sector organisations.
+description: GOV.UK Pay is for central government, local authorities, police and the NHS. It lets them take payments quickly, easily and securely.
 ---
 
 <div class="masthead">


### PR DESCRIPTION
Update the description metadata for the main page at https://www.payments.service.gov.uk/ to be:

> GOV.UK Pay is for central government, local authorities, police and the NHS. It lets them take payments quickly, easily and securely.

This is used in two `meta` elements as the value of the `content` attribute:

- The `meta` element with a `name` attribute of `description` as specified at https://html.spec.whatwg.org/#meta-description
- The `meta` element with a `property` attribute of `og:description` — that is, the Open Graph `og:description` tag specified at https://developers.facebook.com/docs/sharing/webmasters/#basic