### PR TITLE
PP-13869 Update main page masthead

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -17,27 +17,19 @@ description: GOV.UK Pay is for central government, local authorities, police and
     </div>
     <div class="hero__content">
       <div class="hero__body">
-        <h1 class="hero__title">Take online payments from your users</h1>
+        <h1 class="hero__title">The best way to take payments for public services</h1>
+        <p class="hero__description">
+          GOV.UK&nbsp;Pay has contracts with payment providers so you can take payments quickly and easily. It’s used across central and local government, police and the NHS.
+        </p>
         <div class="hero__inline-image">
           <%= image_tag 'pay-top-image.png', alt: 'Payment screen on mobile and dashboard with refund function.', role: 'presentation' %>
         </div>
-        <p class="hero__description">If you work in the public sector, use GOV.UK&nbsp;Pay to take&nbsp;payments</p>
         <% link_to 'getstarted', :role => 'button', :class => 'govuk-button govuk-button--start button--start_white', 'data-click-events' => '', 'data-click-category' => 'Hero', 'data-click-action' => 'Internal link clicked' do %>
-          Create a test account
+          Find out if you can use GOV.UK&nbsp;Pay
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
           </svg>
         <% end %>
-        <span class="hero-alternative-action">
-          or
-          <%=
-            link_to 'find out what GOV.UK&nbsp;Pay offers',
-                    'using-govuk-pay',
-                    'data-click-events' => '',
-                    'data-click-category' => 'Hero',
-                    'data-click-action' => 'Internal link clicked'
-          %>
-        </span>
       </div>
       <div class="hero__aside-image">
         <%= image_tag 'pay-top-image.png', alt: 'Payment screen on mobile and dashboard with refund function.', role: 'presentation' %>

--- a/source/stylesheets/modules/_hero.scss
+++ b/source/stylesheets/modules/_hero.scss
@@ -78,6 +78,13 @@
   }
 
   &__inline-image {
+    // Not in original product-page-example
+    // Added because we relocated the image
+    // to be immediately above the button
+    // and the extra margin is necessary to
+    // give the button space to breathe
+    margin-bottom: govuk-spacing(3);
+
     text-align: center;
 
     @include govuk-media-query(tablet) {


### PR DESCRIPTION
- Change heading from “Take online payments from your users” to “The best way to take payments for public services”.
- Change text from “If you work in the public sector, use GOV.UK Pay to take payments” to “GOV.UK Pay has contracts with payment providers so you can take payments quickly and easily. It’s used across central and local government, police and the NHS.”
- Change button text from “Create a test account” to “Find out if you can use GOV.UK Pay”.
- Remove “or find out what GOV.UK Pay offers” alternative action.
- Deviate from the [product-page-example](https://github.com/alphagov/product-page-example/) by making it so that the inline image (shown on narrow screens like mobile phones) appears under the text and above the button rather than under the heading and above the text. Add extra margin to the bottom of the inline image to give the button space to breathe.

## Screenshots
### Wide
![image](https://github.com/user-attachments/assets/0a738e3a-90c4-4b75-9d7e-cd9987ad240d)
---
### Just wide enough that the side margins are minimal
![image](https://github.com/user-attachments/assets/6469f174-a33d-4a2e-82fd-506071cefa2a)
---
### Narrow enough that the text wraps in a different place
![image](https://github.com/user-attachments/assets/e87ac7a4-e5bf-4df6-aedb-01c88e6e4cf7)
---
### Narrow enough that the heading wraps in a different place
![image](https://github.com/user-attachments/assets/316e8bc1-2718-4a05-a7a0-32635f91a0dc)
---
### Narrow enough that the menu bar wraps
![image](https://github.com/user-attachments/assets/97c83b66-3afd-4675-9b9d-2bd8f28bcd99)
---
### As narrow as it can get before the menu bar collapses into a drop-down
![image](https://github.com/user-attachments/assets/551fefae-73a8-421d-acb3-c39645391fd3)
---
### Narrow enough that the menu bar collapses into a drop-down
![image](https://github.com/user-attachments/assets/73dd0e86-c340-4749-9e81-30c865a3567a)
---
### Narrow enough that the button text wraps
![image](https://github.com/user-attachments/assets/ef805a63-896b-47e7-b991-90a8193cc3b1)
---
### Narrow enough that the wrapping is substantially different
![image](https://github.com/user-attachments/assets/c617b839-28b3-4151-9fc4-f3d58e812682)
---
### Narrow enough that the image is no longer to the side
![image](https://github.com/user-attachments/assets/5b72cef9-51b5-4ce1-b365-caa635bf8b7a)
---
### Narrow enough that the wrapping is substantially different again
![image](https://github.com/user-attachments/assets/e07e1271-7269-49c0-a536-477d50f66067)
---
### The narrowest it can get on my web browser
![image](https://github.com/user-attachments/assets/106be63f-f115-4794-bfc7-d7f8c5930dce)
---
### What it looks like with a screen the size of a second-generation iPhone SE
![image](https://github.com/user-attachments/assets/f5cb3be2-1fec-4d3c-8ff9-4bb4125d24be)
