### PR TITLE
 PP-14039 fix typo in Alt text on homepage

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -49,7 +49,7 @@ description: Take and process online payments from your users - GOV.UK Pay is a 
                <p class="govuk-body">There are no monthly bills, setup or upgrade&nbsp;fees.</p>
           </div>
           <div class="govuk-grid-column-one-half">
-            <img class="content-section__image" src="/pay-product-page/images/product-page_images_user-screen.svg" alt="A user-facing payment page with entry fields for card details and a payment summary. A helpful inline error message responds to user input." />
+            <img class="content-section__image" src="/pay-product-page/images/product-page_images_user-screen.svg" alt="A user-facing payment page with entry fields for card details and a payment summary." />
           </div>
       </div>
     </div>


### PR DESCRIPTION
Remove the alt text "A helpful inline error message responds to user input"