### PR TITLE
PP-14039Ccorrect typo  in alt text on homepage

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -57,7 +57,7 @@ description: GOV.UK Pay is for central government, local authorities, police and
         <div class="govuk-grid-column-one-half">
           <%=
             image_tag 'product-page_images_user-screen.svg',
-                      alt: 'A user-facing payment page with entry fields for card details and a payment summary. A helpful inline error message responds to user input.',
+                      alt: 'A user-facing payment page with entry fields for card details and a payment summary.',
                       class: 'content-section__image'
           %>
         </div>


### PR DESCRIPTION
Remove the alt text "A helpful inline error message responds to user input"