### PR TITLE
PP-14184 update metatags and favicon

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -68,16 +80,15 @@
       "name": "StripeDetector"
     },
     {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
       "name": "TwilioKeyDetector"
     }
   ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -118,9 +129,9 @@
         "filename": "source/layouts/layout.html.erb",
         "hashed_secret": "e0cadc1a99504f3acead6e976b5773d8f34e1b94",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 29
       }
     ]
   },
-  "generated_at": "2025-04-07T21:09:15Z"
+  "generated_at": "2025-06-12T11:28:20Z"
 }

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -7,11 +7,13 @@
       <meta name="description" content="<%= current_page.data.description %>" />
     <% end %>
 
-    <link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico" />
-    <link rel="icon" sizes="any" href="/assets/govuk/assets/images/favicon.svg" type="image/svg+xml" />
-    <link rel="mask-icon" href="/assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c" />
-    <link rel="apple-touch-icon" href="/assets/govuk/assets/images/govuk-icon-180.png" />
-    <link rel="mask-icon" href="/assets/govuk/assets/manifest.json" color="#0b0c0c" />
+    <meta name="theme-color" content="#1d70b8" />
+    <link rel="icon" sizes="48x48" href="/assets/govuk/assets/rebrand/images/favicon.ico" />
+    <link rel="icon" sizes="any" href="/assets/govuk/assets/rebrand/images/favicon.svg" type="image/svg+xml" />
+    <link rel="mask-icon" href="/assets/govuk/assets/rebrand/images/govuk-icon-mask.svg" color="#1d70b8" />
+    <link rel="apple-touch-icon" href="/assets/govuk/assets/rebrand/images/govuk-icon-180.png" />
+    <link rel="manifest" href="/assets/govuk/assets/rebrand/manifest.json" />
+    <meta property="og:image" content="/assets/govuk/assets/rebrand/images/govuk-opengraph-image.png" />
 
     <%= meta_tag 'width=device-width, initial-scale=1, viewport-fit=cover', name: 'viewport' %>
     <%= meta_tag '#0b0c0c', name: 'theme-color' %>


### PR DESCRIPTION
Updating the metatags in the layout so that it pulls in the correct assets. See below (specifically the favicon) for changes before (main branch):
<img width="883" alt="Screenshot 2025-06-12 at 12 15 22" src="https://github.com/user-attachments/assets/cf9e8729-4cdc-403f-80bf-d6b21d899655" />
And after (`rebrand_june_2025` branch):
<img width="880" alt="Screenshot 2025-06-12 at 12 17 07" src="https://github.com/user-attachments/assets/2255dfec-d120-4c26-88fb-2c1f5620bb5e" />
