### PR TITLE
PP-14262 Fix footer links layout bug

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -133,7 +133,7 @@
         <div class="govuk-footer__navigation">
           <% about_navigation = { 'Get started' => '/getstarted/', 'Using GOV.UK&nbsp;Pay' => '/using-govuk-pay/', 'Roadmap' => '/roadmap/', 'Performance' => '/performance/' } %>
 
-          <div class="govuk-footer__section govuk-grid-column-one-third">
+          <div class="govuk-footer__section govuk-grid-column-one-half">
             <h2 class="govuk-footer__heading govuk-heading-m">About GOV.UK&nbsp;Pay</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <% about_navigation.each do |text, url| %>
@@ -153,7 +153,7 @@
             }
           %>
 
-          <div class="govuk-footer__section govuk-grid-column-one-third">
+          <div class="govuk-footer__section govuk-grid-column-one-half">
             <h2 class="govuk-footer__heading govuk-heading-m">Support</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <% support_navigation.each do |text, url| %>


### PR DESCRIPTION
- Change link lists to one half of the footer.

![image](https://github.com/user-attachments/assets/4073e1aa-d9c3-4361-806e-706223fd1307)
