### PR TITLE
PP-14278 - Fix footer links

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -172,8 +172,8 @@
               {
                 'Government Digital Service' => 'https://www.gov.uk/government/organisations/government-digital-service',
                 'Privacy notice' => 'https://selfservice.payments.service.gov.uk/privacy',
-                'Cookies' => 'cookies',
-                'Accessibility statement' => 'accessibility-statement'
+                'Cookies' => '/cookies',
+                'Accessibility statement' => '/accessibility-statement'
               }.each_with_index do |(title, url), i|
             %>
                 <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
- The links to the cookies and accessibility page are using relative links - which can produce the wrong link depending on where you are navigating from.
- Adding a `/` so they are starting from the root.