### PR TITLE
PP-14263 Fix sub nav links underline bug

### DIFF
--- a/source/stylesheets/modules/_sub-navigation.scss
+++ b/source/stylesheets/modules/_sub-navigation.scss
@@ -19,8 +19,7 @@
       text-decoration: none;
     }
 
-    a:hover,
-    a:active {
+    a:hover:not(:focus) {
       text-decoration: underline;
     }
 


### PR DESCRIPTION
- No longer shows an underline if you hover over a focused link in the sub navigation.

# Old

Adds an extra underline when you hover over a focused link in the sub navigation:

<img width="1136" height="647" alt="image" src="https://github.com/user-attachments/assets/d7e695d2-be9b-4a44-850f-04758c420f49" />

# New

No underline is added when you hover over the focused link.
The underline now looks thinner.

<img width="1136" height="647" alt="image" src="https://github.com/user-attachments/assets/642a8f19-8863-4ba7-804c-c28428e933da" />

